### PR TITLE
feat(api-docs): Add examples for endpoints which return events

### DIFF
--- a/components/schemas/event.json
+++ b/components/schemas/event.json
@@ -4,5 +4,8 @@
   },
   "EventDetailed": {
     "type": "object"
+  },
+  "Hash": {
+    "type": "object"
   }
 }

--- a/components/schemas/event.json
+++ b/components/schemas/event.json
@@ -5,6 +5,9 @@
   "EventDetailed": {
     "type": "object"
   },
+  "OrganizationEvent": {
+    "type": "object"
+  },
   "Hash": {
     "type": "object"
   }

--- a/openapi-derefed.json
+++ b/openapi-derefed.json
@@ -7882,8 +7882,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 },
                                 {
                                   "function": "apply",
@@ -7946,8 +7945,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 }
                               ],
                               "framesOmitted": null,
@@ -8018,8 +8016,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 },
                                 {
                                   "function": null,
@@ -8082,8 +8079,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 }
                               ],
                               "framesOmitted": null,
@@ -9395,8 +9391,7 @@
                                       ],
                                       "symbolAddr": null,
                                       "trust": null,
-                                      "symbol": null,
-                                      "rawFunction": null
+                                      "symbol": null
                                     },
                                     {
                                       "function": "apply",
@@ -9459,8 +9454,7 @@
                                       ],
                                       "symbolAddr": null,
                                       "trust": null,
-                                      "symbol": null,
-                                      "rawFunction": null
+                                      "symbol": null
                                     }
                                   ],
                                   "framesOmitted": null,
@@ -9531,8 +9525,7 @@
                                       ],
                                       "symbolAddr": null,
                                       "trust": null,
-                                      "symbol": null,
-                                      "rawFunction": null
+                                      "symbol": null
                                     },
                                     {
                                       "function": null,
@@ -9595,8 +9588,7 @@
                                       ],
                                       "symbolAddr": null,
                                       "trust": null,
-                                      "symbol": null,
-                                      "rawFunction": null
+                                      "symbol": null
                                     }
                                   ],
                                   "framesOmitted": null,
@@ -9925,8 +9917,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 },
                                 {
                                   "function": "apply",
@@ -9989,8 +9980,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 }
                               ],
                               "framesOmitted": null,
@@ -10061,8 +10051,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 },
                                 {
                                   "function": null,
@@ -10125,8 +10114,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 }
                               ],
                               "framesOmitted": null,
@@ -10561,8 +10549,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 },
                                 {
                                   "function": "apply",
@@ -10625,8 +10612,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 }
                               ],
                               "framesOmitted": null,
@@ -10697,8 +10683,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 },
                                 {
                                   "function": null,
@@ -10761,8 +10746,7 @@
                                   ],
                                   "symbolAddr": null,
                                   "trust": null,
-                                  "symbol": null,
-                                  "rawFunction": null
+                                  "symbol": null
                                 }
                               ],
                               "framesOmitted": null,

--- a/openapi-derefed.json
+++ b/openapi-derefed.json
@@ -50,6 +50,14 @@
         "description": "Found an error? Let us know.",
         "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/organizations/&template=api_error_template.md"
       }
+    },
+    {
+      "name": "Releases",
+      "description": "Endpoints for releases",
+      "externalDocs": {
+        "description": "Found an error? Let us know.",
+        "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/teams/&template=api_error_template.md"
+      }
     }
   ],
   "paths": {
@@ -1352,30 +1360,102 @@
                   }
                 },
                 "example": [
-                  [1541455200, 3302],
-                  [1541458800, 3832],
-                  [1541462400, 3669],
-                  [1541466000, 3533],
-                  [1541469600, 3499],
-                  [1541473200, 3201],
-                  [1541476800, 3769],
-                  [1541480400, 2706],
-                  [1541484000, 2698],
-                  [1541487600, 3747],
-                  [1541491200, 3261],
-                  [1541494800, 2860],
-                  [1541498400, 4350],
-                  [1541502000, 2924],
-                  [1541505600, 3389],
-                  [1541509200, 2931],
-                  [1541512800, 3132],
-                  [1541516400, 3213],
-                  [1541520000, 3650],
-                  [1541523600, 3096],
-                  [1541527200, 3845],
-                  [1541530800, 3545],
-                  [1541534400, 2880],
-                  [1541538000, 4057]
+                  [
+                    1541455200,
+                    3302
+                  ],
+                  [
+                    1541458800,
+                    3832
+                  ],
+                  [
+                    1541462400,
+                    3669
+                  ],
+                  [
+                    1541466000,
+                    3533
+                  ],
+                  [
+                    1541469600,
+                    3499
+                  ],
+                  [
+                    1541473200,
+                    3201
+                  ],
+                  [
+                    1541476800,
+                    3769
+                  ],
+                  [
+                    1541480400,
+                    2706
+                  ],
+                  [
+                    1541484000,
+                    2698
+                  ],
+                  [
+                    1541487600,
+                    3747
+                  ],
+                  [
+                    1541491200,
+                    3261
+                  ],
+                  [
+                    1541494800,
+                    2860
+                  ],
+                  [
+                    1541498400,
+                    4350
+                  ],
+                  [
+                    1541502000,
+                    2924
+                  ],
+                  [
+                    1541505600,
+                    3389
+                  ],
+                  [
+                    1541509200,
+                    2931
+                  ],
+                  [
+                    1541512800,
+                    3132
+                  ],
+                  [
+                    1541516400,
+                    3213
+                  ],
+                  [
+                    1541520000,
+                    3650
+                  ],
+                  [
+                    1541523600,
+                    3096
+                  ],
+                  [
+                    1541527200,
+                    3845
+                  ],
+                  [
+                    1541530800,
+                    3545
+                  ],
+                  [
+                    1541534400,
+                    2880
+                  ],
+                  [
+                    1541538000,
+                    4057
+                  ]
                 ]
               }
             }
@@ -1576,11 +1656,148 @@
                   }
                 },
                 "example": {
+                  "event": {
+                    "_meta": {
+                      "context": null,
+                      "contexts": null,
+                      "entries": {},
+                      "message": null,
+                      "packages": null,
+                      "sdk": null,
+                      "tags": {},
+                      "user": null
+                    },
+                    "context": {
+                      "emptyList": [],
+                      "emptyMap": {},
+                      "length": 10837790,
+                      "results": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5
+                      ],
+                      "session": {
+                        "foo": "bar"
+                      },
+                      "unauthorized": false,
+                      "url": "http://example.org/foo/bar/"
+                    },
+                    "contexts": {},
+                    "dateCreated": "2018-11-06T21:19:55Z",
+                    "dateReceived": "2018-11-06T21:19:55Z",
+                    "dist": null,
+                    "entries": [
+                      {
+                        "data": {
+                          "cookies": [
+                            [
+                              "foo",
+                              "bar"
+                            ],
+                            [
+                              "biz",
+                              "baz"
+                            ]
+                          ],
+                          "data": {
+                            "hello": "world"
+                          },
+                          "env": {
+                            "ENV": "prod"
+                          },
+                          "fragment": "",
+                          "headers": [
+                            [
+                              "Content-Type",
+                              "application/json"
+                            ],
+                            [
+                              "Referer",
+                              "http://example.com"
+                            ],
+                            [
+                              "User-Agent",
+                              "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.72 Safari/537.36"
+                            ]
+                          ],
+                          "inferredContentType": "application/json",
+                          "method": "GET",
+                          "query": "foo=bar",
+                          "url": "http://example.com/foo"
+                        },
+                        "type": "request"
+                      }
+                    ],
+                    "errors": [],
+                    "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",
+                    "fingerprints": [
+                      "c4a4d06bc314205bb3b6bdb612dde7f1"
+                    ],
+                    "groupID": "1",
+                    "id": "1",
+                    "message": "This is an example Python exception",
+                    "metadata": {
+                      "title": "This is an example Python exception"
+                    },
+                    "packages": {
+                      "my.package": "1.0.0"
+                    },
+                    "platform": "python",
+                    "sdk": null,
+                    "size": 7055,
+                    "tags": [
+                      {
+                        "_meta": null,
+                        "key": "browser",
+                        "value": "Chrome 28.0"
+                      },
+                      {
+                        "_meta": null,
+                        "key": "device",
+                        "value": "Other"
+                      },
+                      {
+                        "_meta": null,
+                        "key": "level",
+                        "value": "error"
+                      },
+                      {
+                        "_meta": null,
+                        "key": "os",
+                        "value": "Windows 8"
+                      },
+                      {
+                        "_meta": null,
+                        "key": "release",
+                        "value": "17642328ead24b51867165985996d04b29310337"
+                      },
+                      {
+                        "_meta": null,
+                        "key": "url",
+                        "value": "http://example.com/foo"
+                      },
+                      {
+                        "_meta": null,
+                        "key": "user",
+                        "value": "id:1"
+                      }
+                    ],
+                    "type": "default",
+                    "user": {
+                      "data": {},
+                      "email": "sentry@example.com",
+                      "id": "1",
+                      "ip_address": "127.0.0.1",
+                      "name": "Sentry",
+                      "username": "sentry"
+                    }
+                  },
                   "eventId": "1",
                   "groupId": "1",
                   "organizationSlug": "the-interstellar-jurisdiction",
-                  "projectSlug": "pump-station",
-                  "event": {}
+                  "projectSlug": "pump-station"
                 }
               }
             }
@@ -2898,7 +3115,8 @@
                     ],
                     "properties": {
                       "dateCreated": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "date-time"
                       },
                       "id": {
                         "type": "string"
@@ -3010,30 +3228,102 @@
                   }
                 },
                 "example": [
-                  [1541455200, 8264],
-                  [1541458800, 6564],
-                  [1541462400, 8652],
-                  [1541466000, 7436],
-                  [1541469600, 8127],
-                  [1541473200, 7643],
-                  [1541476800, 6518],
-                  [1541480400, 6752],
-                  [1541484000, 6559],
-                  [1541487600, 7039],
-                  [1541491200, 7384],
-                  [1541494800, 6265],
-                  [1541498400, 8390],
-                  [1541502000, 6393],
-                  [1541505600, 7298],
-                  [1541509200, 7422],
-                  [1541512800, 5603],
-                  [1541516400, 6846],
-                  [1541520000, 8886],
-                  [1541523600, 6544],
-                  [1541527200, 8812],
-                  [1541530800, 8172],
-                  [1541534400, 5733],
-                  [1541538000, 9435]
+                  [
+                    1541455200,
+                    8264
+                  ],
+                  [
+                    1541458800,
+                    6564
+                  ],
+                  [
+                    1541462400,
+                    8652
+                  ],
+                  [
+                    1541466000,
+                    7436
+                  ],
+                  [
+                    1541469600,
+                    8127
+                  ],
+                  [
+                    1541473200,
+                    7643
+                  ],
+                  [
+                    1541476800,
+                    6518
+                  ],
+                  [
+                    1541480400,
+                    6752
+                  ],
+                  [
+                    1541484000,
+                    6559
+                  ],
+                  [
+                    1541487600,
+                    7039
+                  ],
+                  [
+                    1541491200,
+                    7384
+                  ],
+                  [
+                    1541494800,
+                    6265
+                  ],
+                  [
+                    1541498400,
+                    8390
+                  ],
+                  [
+                    1541502000,
+                    6393
+                  ],
+                  [
+                    1541505600,
+                    7298
+                  ],
+                  [
+                    1541509200,
+                    7422
+                  ],
+                  [
+                    1541512800,
+                    5603
+                  ],
+                  [
+                    1541516400,
+                    6846
+                  ],
+                  [
+                    1541520000,
+                    8886
+                  ],
+                  [
+                    1541523600,
+                    6544
+                  ],
+                  [
+                    1541527200,
+                    8812
+                  ],
+                  [
+                    1541530800,
+                    8172
+                  ],
+                  [
+                    1541534400,
+                    5733
+                  ],
+                  [
+                    1541538000,
+                    9435
+                  ]
                 ]
               }
             }
@@ -5852,30 +6142,102 @@
                   }
                 },
                 "example": [
-                  [1541455200, 1184],
-                  [1541458800, 1410],
-                  [1541462400, 1440],
-                  [1541466000, 1682],
-                  [1541469600, 1203],
-                  [1541473200, 497],
-                  [1541476800, 661],
-                  [1541480400, 1481],
-                  [1541484000, 678],
-                  [1541487600, 1857],
-                  [1541491200, 819],
-                  [1541494800, 1013],
-                  [1541498400, 1883],
-                  [1541502000, 1450],
-                  [1541505600, 1102],
-                  [1541509200, 1317],
-                  [1541512800, 1017],
-                  [1541516400, 813],
-                  [1541520000, 1189],
-                  [1541523600, 496],
-                  [1541527200, 1936],
-                  [1541530800, 1405],
-                  [1541534400, 617],
-                  [1541538000, 1533]
+                  [
+                    1541455200,
+                    1184
+                  ],
+                  [
+                    1541458800,
+                    1410
+                  ],
+                  [
+                    1541462400,
+                    1440
+                  ],
+                  [
+                    1541466000,
+                    1682
+                  ],
+                  [
+                    1541469600,
+                    1203
+                  ],
+                  [
+                    1541473200,
+                    497
+                  ],
+                  [
+                    1541476800,
+                    661
+                  ],
+                  [
+                    1541480400,
+                    1481
+                  ],
+                  [
+                    1541484000,
+                    678
+                  ],
+                  [
+                    1541487600,
+                    1857
+                  ],
+                  [
+                    1541491200,
+                    819
+                  ],
+                  [
+                    1541494800,
+                    1013
+                  ],
+                  [
+                    1541498400,
+                    1883
+                  ],
+                  [
+                    1541502000,
+                    1450
+                  ],
+                  [
+                    1541505600,
+                    1102
+                  ],
+                  [
+                    1541509200,
+                    1317
+                  ],
+                  [
+                    1541512800,
+                    1017
+                  ],
+                  [
+                    1541516400,
+                    813
+                  ],
+                  [
+                    1541520000,
+                    1189
+                  ],
+                  [
+                    1541523600,
+                    496
+                  ],
+                  [
+                    1541527200,
+                    1936
+                  ],
+                  [
+                    1541530800,
+                    1405
+                  ],
+                  [
+                    1541534400,
+                    617
+                  ],
+                  [
+                    1541538000,
+                    1533
+                  ]
                 ]
               }
             }
@@ -7380,6 +7742,600 @@
               "application/json": {
                 "schema": {
                   "type": "object"
+                },
+                "example": {
+                  "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+                  "dist": null,
+                  "userReport": null,
+                  "previousEventID": null,
+                  "message": "",
+                  "id": "9999aaafcc8b46d797c23c6077c6ff01",
+                  "size": 107762,
+                  "errors": [
+                    {
+                      "data": {
+                        "column": 8,
+                        "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                        "row": 15
+                      },
+                      "message": "Invalid location in sourcemap",
+                      "type": "js_invalid_sourcemap_location"
+                    }
+                  ],
+                  "platform": "javascript",
+                  "nextEventID": "99f9e199e9a74a14bfef6196ad741619",
+                  "type": "error",
+                  "metadata": {
+                    "type": "ForbiddenError",
+                    "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+                  },
+                  "tags": [
+                    {
+                      "value": "Chrome 83.0.4103",
+                      "key": "browser",
+                      "_meta": null
+                    },
+                    {
+                      "value": "Chrome",
+                      "key": "browser.name",
+                      "_meta": null
+                    },
+                    {
+                      "value": "prod",
+                      "key": "environment",
+                      "_meta": null
+                    },
+                    {
+                      "value": "yes",
+                      "key": "handled",
+                      "_meta": null
+                    },
+                    {
+                      "value": "error",
+                      "key": "level",
+                      "_meta": null
+                    },
+                    {
+                      "value": "generic",
+                      "key": "mechanism",
+                      "_meta": null
+                    }
+                  ],
+                  "dateCreated": "2020-06-17T22:26:56.098086Z",
+                  "dateReceived": "2020-06-17T22:26:56.428721Z",
+                  "user": {
+                    "username": null,
+                    "name": "Hell Boy",
+                    "ip_address": "192.168.1.1",
+                    "email": "hell@boy.cat",
+                    "data": {
+                      "isStaff": false
+                    },
+                    "id": "550747"
+                  },
+                  "entries": [
+                    {
+                      "type": "exception",
+                      "data": {
+                        "values": [
+                          {
+                            "stacktrace": {
+                              "frames": [
+                                {
+                                  "function": "ignoreOnError",
+                                  "errors": null,
+                                  "colNo": 23,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "inApp": false,
+                                  "lineNo": 71,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      66,
+                                      "            }"
+                                    ],
+                                    [
+                                      67,
+                                      "            // Attempt to invoke user-land function"
+                                    ],
+                                    [
+                                      68,
+                                      "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                    ],
+                                    [
+                                      69,
+                                      "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                    ],
+                                    [
+                                      70,
+                                      "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                    ],
+                                    [
+                                      71,
+                                      "            return fn.apply(this, wrappedArguments);"
+                                    ],
+                                    [
+                                      72,
+                                      "            // tslint:enable:no-unsafe-any"
+                                    ],
+                                    [
+                                      73,
+                                      "        }"
+                                    ],
+                                    [
+                                      74,
+                                      "        catch (ex) {"
+                                    ],
+                                    [
+                                      75,
+                                      "            ignoreNextOnError();"
+                                    ],
+                                    [
+                                      76,
+                                      "            withScope(function (scope) {"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": "apply",
+                                  "errors": null,
+                                  "colNo": 24,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "inApp": false,
+                                  "lineNo": 74,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      69,
+                                      "     */"
+                                    ],
+                                    [
+                                      70,
+                                      "    triggerAsync: function triggerAsync() {"
+                                    ],
+                                    [
+                                      71,
+                                      "        var args = arguments,"
+                                    ],
+                                    [
+                                      72,
+                                      "            me = this;"
+                                    ],
+                                    [
+                                      73,
+                                      "        _.nextTick(function () {"
+                                    ],
+                                    [
+                                      74,
+                                      "            me.trigger.apply(me, args);"
+                                    ],
+                                    [
+                                      75,
+                                      "        });"
+                                    ],
+                                    [
+                                      76,
+                                      "    },"
+                                    ],
+                                    [
+                                      77,
+                                      ""
+                                    ],
+                                    [
+                                      78,
+                                      "    /**"
+                                    ],
+                                    [
+                                      79,
+                                      "     * Wraps the trigger mechanism with a deferral function."
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "module": null,
+                            "rawStacktrace": {
+                              "frames": [
+                                {
+                                  "function": "a",
+                                  "errors": null,
+                                  "colNo": 88800,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 81,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      76,
+                                      "/*!"
+                                    ],
+                                    [
+                                      77,
+                                      "  Copyright (c) 2018 Jed Watson."
+                                    ],
+                                    [
+                                      78,
+                                      "  Licensed under the MIT License (MIT), see"
+                                    ],
+                                    [
+                                      79,
+                                      "  http://jedwatson.github.io/react-select"
+                                    ],
+                                    [
+                                      80,
+                                      "*/"
+                                    ],
+                                    [
+                                      81,
+                                      "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                    ],
+                                    [
+                                      82,
+                                      "/*!"
+                                    ],
+                                    [
+                                      83,
+                                      " * JavaScript Cookie v2.2.1"
+                                    ],
+                                    [
+                                      84,
+                                      " * https://github.com/js-cookie/js-cookie"
+                                    ],
+                                    [
+                                      85,
+                                      " *"
+                                    ],
+                                    [
+                                      86,
+                                      " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": null,
+                                  "errors": null,
+                                  "colNo": 149484,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 119,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      114,
+                                      "/* @license"
+                                    ],
+                                    [
+                                      115,
+                                      "Papa Parse"
+                                    ],
+                                    [
+                                      116,
+                                      "v5.2.0"
+                                    ],
+                                    [
+                                      117,
+                                      "https://github.com/mholt/PapaParse"
+                                    ],
+                                    [
+                                      118,
+                                      "License: MIT"
+                                    ],
+                                    [
+                                      119,
+                                      "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                    ],
+                                    [
+                                      120,
+                                      "/**!"
+                                    ],
+                                    [
+                                      121,
+                                      " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                    ],
+                                    [
+                                      122,
+                                      " * @version 1.16.1"
+                                    ],
+                                    [
+                                      123,
+                                      " * @license"
+                                    ],
+                                    [
+                                      124,
+                                      " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "mechanism": {
+                              "type": "generic",
+                              "handled": true
+                            },
+                            "threadId": null,
+                            "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                            "type": "ForbiddenError"
+                          }
+                        ],
+                        "excOmitted": null,
+                        "hasSystemFrames": true
+                      }
+                    },
+                    {
+                      "type": "breadcrumbs",
+                      "data": {
+                        "values": [
+                          {
+                            "category": "tracing",
+                            "level": "debug",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.266586Z",
+                            "data": null,
+                            "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                            "type": "debug"
+                          },
+                          {
+                            "category": "xhr",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.619446Z",
+                            "data": {
+                              "url": "/api/0/internal/health/",
+                              "status_code": 200,
+                              "method": "GET"
+                            },
+                            "message": null,
+                            "type": "http"
+                          },
+                          {
+                            "category": "sentry.transaction",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.945016Z",
+                            "data": null,
+                            "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                            "type": "default"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "request",
+                      "data": {
+                        "fragment": null,
+                        "cookies": [],
+                        "inferredContentType": null,
+                        "env": null,
+                        "headers": [
+                          [
+                            "User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                          ]
+                        ],
+                        "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                        "query": [
+                          [
+                            "project",
+                            "5236886"
+                          ]
+                        ],
+                        "data": null,
+                        "method": null
+                      }
+                    }
+                  ],
+                  "packages": {},
+                  "sdk": {
+                    "version": "5.17.0",
+                    "name": "sentry.javascript.browser"
+                  },
+                  "_meta": {
+                    "user": null,
+                    "context": null,
+                    "entries": {},
+                    "contexts": null,
+                    "message": null,
+                    "packages": null,
+                    "tags": {},
+                    "sdk": null
+                  },
+                  "contexts": {
+                    "ForbiddenError": {
+                      "status": 403,
+                      "statusText": "Forbidden",
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "type": "default"
+                    },
+                    "browser": {
+                      "version": "83.0.4103",
+                      "type": "browser",
+                      "name": "Chrome"
+                    },
+                    "os": {
+                      "version": "10",
+                      "type": "os",
+                      "name": "Windows"
+                    },
+                    "trace": {
+                      "span_id": "83db1ad17e67dfe7",
+                      "type": "trace",
+                      "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                      "op": "navigation"
+                    },
+                    "organization": {
+                      "type": "default",
+                      "id": "323938",
+                      "slug": "hellboy-meowmeow"
+                    }
+                  },
+                  "fingerprints": [
+                    "fbe908cc63d63ea9763fd84cb6bad177"
+                  ],
+                  "context": {
+                    "resp": {
+                      "status": 403,
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "name": "ForbiddenError",
+                      "statusText": "Forbidden",
+                      "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                      "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                    }
+                  },
+                  "release": {
+                    "dateReleased": "2020-06-17T19:21:02.186004Z",
+                    "newGroups": 4,
+                    "commitCount": 11,
+                    "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                    "data": {},
+                    "lastDeploy": {
+                      "name": "b65bc521378269d3eaefdc964f8ef56621414943 to prod",
+                      "url": null,
+                      "environment": "prod",
+                      "dateStarted": null,
+                      "dateFinished": "2020-06-17T19:20:55.641748Z",
+                      "id": "6883490"
+                    },
+                    "deployCount": 1,
+                    "dateCreated": "2020-06-17T18:45:31.042157Z",
+                    "lastEvent": "2020-07-08T21:21:21Z",
+                    "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                    "firstEvent": "2020-06-17T22:25:14Z",
+                    "lastCommit": {
+                      "repository": {
+                        "status": "active",
+                        "integrationId": "2933",
+                        "externalSlug": "getsentry/getsentry",
+                        "name": "getsentry/getsentry",
+                        "provider": {
+                          "id": "integrations:github",
+                          "name": "GitHub"
+                        },
+                        "url": "https://github.com/getsentry/getsentry",
+                        "id": "2",
+                        "dateCreated": "2016-10-10T21:36:45.373994Z"
+                      },
+                      "releases": [
+                        {
+                          "dateReleased": "2020-06-23T13:26:18.427090Z",
+                          "url": "https://freight.getsentry.net/deploys/getsentry/staging/2077/",
+                          "dateCreated": "2020-06-23T13:22:50.420265Z",
+                          "version": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                          "shortVersion": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                          "ref": "perf/source-maps-test"
+                        },
+                        {
+                          "dateReleased": "2020-06-17T19:21:02.186004Z",
+                          "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                          "dateCreated": "2020-06-17T18:45:31.042157Z",
+                          "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                          "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                          "ref": "master"
+                        }
+                      ],
+                      "dateCreated": "2020-06-17T18:43:37Z",
+                      "message": "feat(billing): Get a lot of money",
+                      "id": "b65bc521378269d3eaefdc964f8ef56621414943"
+                    },
+                    "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                    "authors": [
+                      {
+                        "username": "a37a1b4520ce46cea147ae2885a4e7e7",
+                        "lastLogin": "2020-09-14T22:34:55.550640Z",
+                        "isSuperuser": false,
+                        "isManaged": false,
+                        "experiments": {},
+                        "lastActive": "2020-09-15T22:13:20.503880Z",
+                        "isStaff": false,
+                        "id": "655784",
+                        "isActive": true,
+                        "has2fa": false,
+                        "name": "hell.boy@sentry.io",
+                        "avatarUrl": "https://secure.gravatar.com/avatar/eaa22e25b3a984659420831a77e4874e?s=32&d=mm",
+                        "dateJoined": "2020-04-20T16:21:25.365772Z",
+                        "emails": [
+                          {
+                            "is_verified": false,
+                            "id": "784574",
+                            "email": "hellboy@gmail.com"
+                          },
+                          {
+                            "is_verified": true,
+                            "id": "749185",
+                            "email": "hell.boy@sentry.io"
+                          }
+                        ],
+                        "avatar": {
+                          "avatarUuid": null,
+                          "avatarType": "letter_avatar"
+                        },
+                        "hasPasswordAuth": false,
+                        "email": "hell.boy@sentry.io"
+                      }
+                    ],
+                    "owner": null,
+                    "ref": "master",
+                    "projects": [
+                      {
+                        "name": "Sentry CSP",
+                        "slug": "sentry-csp"
+                      },
+                      {
+                        "name": "Backend",
+                        "slug": "sentry"
+                      },
+                      {
+                        "name": "Frontend",
+                        "slug": "javascript"
+                      }
+                    ]
+                  },
+                  "groupID": "1341191803"
                 }
               }
             }
@@ -7442,7 +8398,53 @@
                   "items": {
                     "type": "object"
                   }
-                }
+                },
+                "example": [
+                  {
+                    "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",
+                    "tags": [
+                      {
+                        "key": "browser",
+                        "value": "Chrome 60.0"
+                      },
+                      {
+                        "key": "device",
+                        "value": "Other"
+                      },
+                      {
+                        "key": "environment",
+                        "value": "production"
+                      },
+                      {
+                        "value": "fatal",
+                        "key": "level"
+                      },
+                      {
+                        "key": "os",
+                        "value": "Mac OS X 10.12.6"
+                      },
+                      {
+                        "value": "CPython 2.7.16",
+                        "key": "runtime"
+                      },
+                      {
+                        "key": "release",
+                        "value": "17642328ead24b51867165985996d04b29310337"
+                      },
+                      {
+                        "key": "server_name",
+                        "value": "web1.example.com"
+                      }
+                    ],
+                    "dateCreated": "2020-09-11T17:46:36Z",
+                    "user": null,
+                    "message": "This is an example Python exception",
+                    "id": "dfb1a2d057194e76a4186cc8a5271553",
+                    "platform": "python",
+                    "event.type": "error",
+                    "groupID": "1889724436"
+                  }
+                ]
               }
             }
           },
@@ -8253,7 +9255,495 @@
                       }
                     }
                   }
-                }
+                },
+                "example": [
+                  {
+                    "id": "dhgjkldfsghdfakjgh",
+                    "latestEvent": {
+                      "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+                      "dist": null,
+                      "message": "",
+                      "id": "9999aaafcc8b46d797c23c6077c6ff01",
+                      "size": 107762,
+                      "errors": [
+                        {
+                          "data": {
+                            "column": 8,
+                            "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                            "row": 15
+                          },
+                          "message": "Invalid location in sourcemap",
+                          "type": "js_invalid_sourcemap_location"
+                        }
+                      ],
+                      "platform": "javascript",
+                      "type": "error",
+                      "metadata": {
+                        "type": "ForbiddenError",
+                        "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+                      },
+                      "tags": [
+                        {
+                          "value": "Chrome 83.0.4103",
+                          "key": "browser",
+                          "_meta": null
+                        },
+                        {
+                          "value": "Chrome",
+                          "key": "browser.name",
+                          "_meta": null
+                        },
+                        {
+                          "value": "prod",
+                          "key": "environment",
+                          "_meta": null
+                        },
+                        {
+                          "value": "yes",
+                          "key": "handled",
+                          "_meta": null
+                        },
+                        {
+                          "value": "error",
+                          "key": "level",
+                          "_meta": null
+                        },
+                        {
+                          "value": "generic",
+                          "key": "mechanism",
+                          "_meta": null
+                        }
+                      ],
+                      "dateCreated": "2020-06-17T22:26:56.098086Z",
+                      "dateReceived": "2020-06-17T22:26:56.428721Z",
+                      "user": {
+                        "username": null,
+                        "name": "Hell Boy",
+                        "ip_address": "192.168.1.1",
+                        "email": "hell@boy.cat",
+                        "data": {
+                          "isStaff": false
+                        },
+                        "id": "550747"
+                      },
+                      "entries": [
+                        {
+                          "type": "exception",
+                          "data": {
+                            "values": [
+                              {
+                                "stacktrace": {
+                                  "frames": [
+                                    {
+                                      "function": "ignoreOnError",
+                                      "errors": null,
+                                      "colNo": 23,
+                                      "vars": null,
+                                      "package": null,
+                                      "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                      "inApp": false,
+                                      "lineNo": 71,
+                                      "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                                      "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                      "platform": null,
+                                      "instructionAddr": null,
+                                      "context": [
+                                        [
+                                          66,
+                                          "            }"
+                                        ],
+                                        [
+                                          67,
+                                          "            // Attempt to invoke user-land function"
+                                        ],
+                                        [
+                                          68,
+                                          "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                        ],
+                                        [
+                                          69,
+                                          "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                        ],
+                                        [
+                                          70,
+                                          "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                        ],
+                                        [
+                                          71,
+                                          "            return fn.apply(this, wrappedArguments);"
+                                        ],
+                                        [
+                                          72,
+                                          "            // tslint:enable:no-unsafe-any"
+                                        ],
+                                        [
+                                          73,
+                                          "        }"
+                                        ],
+                                        [
+                                          74,
+                                          "        catch (ex) {"
+                                        ],
+                                        [
+                                          75,
+                                          "            ignoreNextOnError();"
+                                        ],
+                                        [
+                                          76,
+                                          "            withScope(function (scope) {"
+                                        ]
+                                      ],
+                                      "symbolAddr": null,
+                                      "trust": null,
+                                      "symbol": null,
+                                      "rawFunction": null
+                                    },
+                                    {
+                                      "function": "apply",
+                                      "errors": null,
+                                      "colNo": 24,
+                                      "vars": null,
+                                      "package": null,
+                                      "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                      "inApp": false,
+                                      "lineNo": 74,
+                                      "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                                      "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                      "platform": null,
+                                      "instructionAddr": null,
+                                      "context": [
+                                        [
+                                          69,
+                                          "     */"
+                                        ],
+                                        [
+                                          70,
+                                          "    triggerAsync: function triggerAsync() {"
+                                        ],
+                                        [
+                                          71,
+                                          "        var args = arguments,"
+                                        ],
+                                        [
+                                          72,
+                                          "            me = this;"
+                                        ],
+                                        [
+                                          73,
+                                          "        _.nextTick(function () {"
+                                        ],
+                                        [
+                                          74,
+                                          "            me.trigger.apply(me, args);"
+                                        ],
+                                        [
+                                          75,
+                                          "        });"
+                                        ],
+                                        [
+                                          76,
+                                          "    },"
+                                        ],
+                                        [
+                                          77,
+                                          ""
+                                        ],
+                                        [
+                                          78,
+                                          "    /**"
+                                        ],
+                                        [
+                                          79,
+                                          "     * Wraps the trigger mechanism with a deferral function."
+                                        ]
+                                      ],
+                                      "symbolAddr": null,
+                                      "trust": null,
+                                      "symbol": null,
+                                      "rawFunction": null
+                                    }
+                                  ],
+                                  "framesOmitted": null,
+                                  "registers": null,
+                                  "hasSystemFrames": true
+                                },
+                                "module": null,
+                                "rawStacktrace": {
+                                  "frames": [
+                                    {
+                                      "function": "a",
+                                      "errors": null,
+                                      "colNo": 88800,
+                                      "vars": null,
+                                      "package": null,
+                                      "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                      "inApp": false,
+                                      "lineNo": 81,
+                                      "module": null,
+                                      "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                      "platform": null,
+                                      "instructionAddr": null,
+                                      "context": [
+                                        [
+                                          76,
+                                          "/*!"
+                                        ],
+                                        [
+                                          77,
+                                          "  Copyright (c) 2018 Jed Watson."
+                                        ],
+                                        [
+                                          78,
+                                          "  Licensed under the MIT License (MIT), see"
+                                        ],
+                                        [
+                                          79,
+                                          "  http://jedwatson.github.io/react-select"
+                                        ],
+                                        [
+                                          80,
+                                          "*/"
+                                        ],
+                                        [
+                                          81,
+                                          "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                        ],
+                                        [
+                                          82,
+                                          "/*!"
+                                        ],
+                                        [
+                                          83,
+                                          " * JavaScript Cookie v2.2.1"
+                                        ],
+                                        [
+                                          84,
+                                          " * https://github.com/js-cookie/js-cookie"
+                                        ],
+                                        [
+                                          85,
+                                          " *"
+                                        ],
+                                        [
+                                          86,
+                                          " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                        ]
+                                      ],
+                                      "symbolAddr": null,
+                                      "trust": null,
+                                      "symbol": null,
+                                      "rawFunction": null
+                                    },
+                                    {
+                                      "function": null,
+                                      "errors": null,
+                                      "colNo": 149484,
+                                      "vars": null,
+                                      "package": null,
+                                      "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                      "inApp": false,
+                                      "lineNo": 119,
+                                      "module": null,
+                                      "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                      "platform": null,
+                                      "instructionAddr": null,
+                                      "context": [
+                                        [
+                                          114,
+                                          "/* @license"
+                                        ],
+                                        [
+                                          115,
+                                          "Papa Parse"
+                                        ],
+                                        [
+                                          116,
+                                          "v5.2.0"
+                                        ],
+                                        [
+                                          117,
+                                          "https://github.com/mholt/PapaParse"
+                                        ],
+                                        [
+                                          118,
+                                          "License: MIT"
+                                        ],
+                                        [
+                                          119,
+                                          "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                        ],
+                                        [
+                                          120,
+                                          "/**!"
+                                        ],
+                                        [
+                                          121,
+                                          " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                        ],
+                                        [
+                                          122,
+                                          " * @version 1.16.1"
+                                        ],
+                                        [
+                                          123,
+                                          " * @license"
+                                        ],
+                                        [
+                                          124,
+                                          " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                        ]
+                                      ],
+                                      "symbolAddr": null,
+                                      "trust": null,
+                                      "symbol": null,
+                                      "rawFunction": null
+                                    }
+                                  ],
+                                  "framesOmitted": null,
+                                  "registers": null,
+                                  "hasSystemFrames": true
+                                },
+                                "mechanism": {
+                                  "type": "generic",
+                                  "handled": true
+                                },
+                                "threadId": null,
+                                "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                                "type": "ForbiddenError"
+                              }
+                            ],
+                            "excOmitted": null,
+                            "hasSystemFrames": true
+                          }
+                        },
+                        {
+                          "type": "breadcrumbs",
+                          "data": {
+                            "values": [
+                              {
+                                "category": "tracing",
+                                "level": "debug",
+                                "event_id": null,
+                                "timestamp": "2020-06-17T22:26:55.266586Z",
+                                "data": null,
+                                "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                                "type": "debug"
+                              },
+                              {
+                                "category": "xhr",
+                                "level": "info",
+                                "event_id": null,
+                                "timestamp": "2020-06-17T22:26:55.619446Z",
+                                "data": {
+                                  "url": "/api/0/internal/health/",
+                                  "status_code": 200,
+                                  "method": "GET"
+                                },
+                                "message": null,
+                                "type": "http"
+                              },
+                              {
+                                "category": "sentry.transaction",
+                                "level": "info",
+                                "event_id": null,
+                                "timestamp": "2020-06-17T22:26:55.945016Z",
+                                "data": null,
+                                "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                                "type": "default"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "request",
+                          "data": {
+                            "fragment": null,
+                            "cookies": [],
+                            "inferredContentType": null,
+                            "env": null,
+                            "headers": [
+                              [
+                                "User-Agent",
+                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                              ]
+                            ],
+                            "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                            "query": [
+                              [
+                                "project",
+                                "5236886"
+                              ]
+                            ],
+                            "data": null,
+                            "method": null
+                          }
+                        }
+                      ],
+                      "packages": {},
+                      "sdk": {
+                        "version": "5.17.0",
+                        "name": "sentry.javascript.browser"
+                      },
+                      "_meta": {
+                        "user": null,
+                        "context": null,
+                        "entries": {},
+                        "contexts": null,
+                        "message": null,
+                        "packages": null,
+                        "tags": {},
+                        "sdk": null
+                      },
+                      "contexts": {
+                        "ForbiddenError": {
+                          "status": 403,
+                          "statusText": "Forbidden",
+                          "responseJSON": {
+                            "detail": "You do not have permission to perform this action."
+                          },
+                          "type": "default"
+                        },
+                        "browser": {
+                          "version": "83.0.4103",
+                          "type": "browser",
+                          "name": "Chrome"
+                        },
+                        "os": {
+                          "version": "10",
+                          "type": "os",
+                          "name": "Windows"
+                        },
+                        "trace": {
+                          "span_id": "83db1ad17e67dfe7",
+                          "type": "trace",
+                          "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                          "op": "navigation"
+                        },
+                        "organization": {
+                          "type": "default",
+                          "id": "323938",
+                          "slug": "hellboy-meowmeow"
+                        }
+                      },
+                      "fingerprints": [
+                        "fbe908cc63d63ea9763fd84cb6bad177"
+                      ],
+                      "context": {
+                        "resp": {
+                          "status": 403,
+                          "responseJSON": {
+                            "detail": "You do not have permission to perform this action."
+                          },
+                          "name": "ForbiddenError",
+                          "statusText": "Forbidden",
+                          "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                          "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                        }
+                      },
+                      "groupID": "1341191803"
+                    }
+                  }
+                ]
               }
             }
           },
@@ -8295,6 +9785,600 @@
               "application/json": {
                 "schema": {
                   "type": "object"
+                },
+                "example": {
+                  "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+                  "dist": null,
+                  "userReport": null,
+                  "previousEventID": null,
+                  "message": "",
+                  "id": "9999aaafcc8b46d797c23c6077c6ff01",
+                  "size": 107762,
+                  "errors": [
+                    {
+                      "data": {
+                        "column": 8,
+                        "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                        "row": 15
+                      },
+                      "message": "Invalid location in sourcemap",
+                      "type": "js_invalid_sourcemap_location"
+                    }
+                  ],
+                  "platform": "javascript",
+                  "nextEventID": "99f9e199e9a74a14bfef6196ad741619",
+                  "type": "error",
+                  "metadata": {
+                    "type": "ForbiddenError",
+                    "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+                  },
+                  "tags": [
+                    {
+                      "value": "Chrome 83.0.4103",
+                      "key": "browser",
+                      "_meta": null
+                    },
+                    {
+                      "value": "Chrome",
+                      "key": "browser.name",
+                      "_meta": null
+                    },
+                    {
+                      "value": "prod",
+                      "key": "environment",
+                      "_meta": null
+                    },
+                    {
+                      "value": "yes",
+                      "key": "handled",
+                      "_meta": null
+                    },
+                    {
+                      "value": "error",
+                      "key": "level",
+                      "_meta": null
+                    },
+                    {
+                      "value": "generic",
+                      "key": "mechanism",
+                      "_meta": null
+                    }
+                  ],
+                  "dateCreated": "2020-06-17T22:26:56.098086Z",
+                  "dateReceived": "2020-06-17T22:26:56.428721Z",
+                  "user": {
+                    "username": null,
+                    "name": "Hell Boy",
+                    "ip_address": "192.168.1.1",
+                    "email": "hell@boy.cat",
+                    "data": {
+                      "isStaff": false
+                    },
+                    "id": "550747"
+                  },
+                  "entries": [
+                    {
+                      "type": "exception",
+                      "data": {
+                        "values": [
+                          {
+                            "stacktrace": {
+                              "frames": [
+                                {
+                                  "function": "ignoreOnError",
+                                  "errors": null,
+                                  "colNo": 23,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "inApp": false,
+                                  "lineNo": 71,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      66,
+                                      "            }"
+                                    ],
+                                    [
+                                      67,
+                                      "            // Attempt to invoke user-land function"
+                                    ],
+                                    [
+                                      68,
+                                      "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                    ],
+                                    [
+                                      69,
+                                      "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                    ],
+                                    [
+                                      70,
+                                      "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                    ],
+                                    [
+                                      71,
+                                      "            return fn.apply(this, wrappedArguments);"
+                                    ],
+                                    [
+                                      72,
+                                      "            // tslint:enable:no-unsafe-any"
+                                    ],
+                                    [
+                                      73,
+                                      "        }"
+                                    ],
+                                    [
+                                      74,
+                                      "        catch (ex) {"
+                                    ],
+                                    [
+                                      75,
+                                      "            ignoreNextOnError();"
+                                    ],
+                                    [
+                                      76,
+                                      "            withScope(function (scope) {"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": "apply",
+                                  "errors": null,
+                                  "colNo": 24,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "inApp": false,
+                                  "lineNo": 74,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      69,
+                                      "     */"
+                                    ],
+                                    [
+                                      70,
+                                      "    triggerAsync: function triggerAsync() {"
+                                    ],
+                                    [
+                                      71,
+                                      "        var args = arguments,"
+                                    ],
+                                    [
+                                      72,
+                                      "            me = this;"
+                                    ],
+                                    [
+                                      73,
+                                      "        _.nextTick(function () {"
+                                    ],
+                                    [
+                                      74,
+                                      "            me.trigger.apply(me, args);"
+                                    ],
+                                    [
+                                      75,
+                                      "        });"
+                                    ],
+                                    [
+                                      76,
+                                      "    },"
+                                    ],
+                                    [
+                                      77,
+                                      ""
+                                    ],
+                                    [
+                                      78,
+                                      "    /**"
+                                    ],
+                                    [
+                                      79,
+                                      "     * Wraps the trigger mechanism with a deferral function."
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "module": null,
+                            "rawStacktrace": {
+                              "frames": [
+                                {
+                                  "function": "a",
+                                  "errors": null,
+                                  "colNo": 88800,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 81,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      76,
+                                      "/*!"
+                                    ],
+                                    [
+                                      77,
+                                      "  Copyright (c) 2018 Jed Watson."
+                                    ],
+                                    [
+                                      78,
+                                      "  Licensed under the MIT License (MIT), see"
+                                    ],
+                                    [
+                                      79,
+                                      "  http://jedwatson.github.io/react-select"
+                                    ],
+                                    [
+                                      80,
+                                      "*/"
+                                    ],
+                                    [
+                                      81,
+                                      "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                    ],
+                                    [
+                                      82,
+                                      "/*!"
+                                    ],
+                                    [
+                                      83,
+                                      " * JavaScript Cookie v2.2.1"
+                                    ],
+                                    [
+                                      84,
+                                      " * https://github.com/js-cookie/js-cookie"
+                                    ],
+                                    [
+                                      85,
+                                      " *"
+                                    ],
+                                    [
+                                      86,
+                                      " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": null,
+                                  "errors": null,
+                                  "colNo": 149484,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 119,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      114,
+                                      "/* @license"
+                                    ],
+                                    [
+                                      115,
+                                      "Papa Parse"
+                                    ],
+                                    [
+                                      116,
+                                      "v5.2.0"
+                                    ],
+                                    [
+                                      117,
+                                      "https://github.com/mholt/PapaParse"
+                                    ],
+                                    [
+                                      118,
+                                      "License: MIT"
+                                    ],
+                                    [
+                                      119,
+                                      "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                    ],
+                                    [
+                                      120,
+                                      "/**!"
+                                    ],
+                                    [
+                                      121,
+                                      " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                    ],
+                                    [
+                                      122,
+                                      " * @version 1.16.1"
+                                    ],
+                                    [
+                                      123,
+                                      " * @license"
+                                    ],
+                                    [
+                                      124,
+                                      " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "mechanism": {
+                              "type": "generic",
+                              "handled": true
+                            },
+                            "threadId": null,
+                            "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                            "type": "ForbiddenError"
+                          }
+                        ],
+                        "excOmitted": null,
+                        "hasSystemFrames": true
+                      }
+                    },
+                    {
+                      "type": "breadcrumbs",
+                      "data": {
+                        "values": [
+                          {
+                            "category": "tracing",
+                            "level": "debug",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.266586Z",
+                            "data": null,
+                            "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                            "type": "debug"
+                          },
+                          {
+                            "category": "xhr",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.619446Z",
+                            "data": {
+                              "url": "/api/0/internal/health/",
+                              "status_code": 200,
+                              "method": "GET"
+                            },
+                            "message": null,
+                            "type": "http"
+                          },
+                          {
+                            "category": "sentry.transaction",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.945016Z",
+                            "data": null,
+                            "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                            "type": "default"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "request",
+                      "data": {
+                        "fragment": null,
+                        "cookies": [],
+                        "inferredContentType": null,
+                        "env": null,
+                        "headers": [
+                          [
+                            "User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                          ]
+                        ],
+                        "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                        "query": [
+                          [
+                            "project",
+                            "5236886"
+                          ]
+                        ],
+                        "data": null,
+                        "method": null
+                      }
+                    }
+                  ],
+                  "packages": {},
+                  "sdk": {
+                    "version": "5.17.0",
+                    "name": "sentry.javascript.browser"
+                  },
+                  "_meta": {
+                    "user": null,
+                    "context": null,
+                    "entries": {},
+                    "contexts": null,
+                    "message": null,
+                    "packages": null,
+                    "tags": {},
+                    "sdk": null
+                  },
+                  "contexts": {
+                    "ForbiddenError": {
+                      "status": 403,
+                      "statusText": "Forbidden",
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "type": "default"
+                    },
+                    "browser": {
+                      "version": "83.0.4103",
+                      "type": "browser",
+                      "name": "Chrome"
+                    },
+                    "os": {
+                      "version": "10",
+                      "type": "os",
+                      "name": "Windows"
+                    },
+                    "trace": {
+                      "span_id": "83db1ad17e67dfe7",
+                      "type": "trace",
+                      "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                      "op": "navigation"
+                    },
+                    "organization": {
+                      "type": "default",
+                      "id": "323938",
+                      "slug": "hellboy-meowmeow"
+                    }
+                  },
+                  "fingerprints": [
+                    "fbe908cc63d63ea9763fd84cb6bad177"
+                  ],
+                  "context": {
+                    "resp": {
+                      "status": 403,
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "name": "ForbiddenError",
+                      "statusText": "Forbidden",
+                      "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                      "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                    }
+                  },
+                  "release": {
+                    "dateReleased": "2020-06-17T19:21:02.186004Z",
+                    "newGroups": 4,
+                    "commitCount": 11,
+                    "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                    "data": {},
+                    "lastDeploy": {
+                      "name": "b65bc521378269d3eaefdc964f8ef56621414943 to prod",
+                      "url": null,
+                      "environment": "prod",
+                      "dateStarted": null,
+                      "dateFinished": "2020-06-17T19:20:55.641748Z",
+                      "id": "6883490"
+                    },
+                    "deployCount": 1,
+                    "dateCreated": "2020-06-17T18:45:31.042157Z",
+                    "lastEvent": "2020-07-08T21:21:21Z",
+                    "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                    "firstEvent": "2020-06-17T22:25:14Z",
+                    "lastCommit": {
+                      "repository": {
+                        "status": "active",
+                        "integrationId": "2933",
+                        "externalSlug": "getsentry/getsentry",
+                        "name": "getsentry/getsentry",
+                        "provider": {
+                          "id": "integrations:github",
+                          "name": "GitHub"
+                        },
+                        "url": "https://github.com/getsentry/getsentry",
+                        "id": "2",
+                        "dateCreated": "2016-10-10T21:36:45.373994Z"
+                      },
+                      "releases": [
+                        {
+                          "dateReleased": "2020-06-23T13:26:18.427090Z",
+                          "url": "https://freight.getsentry.net/deploys/getsentry/staging/2077/",
+                          "dateCreated": "2020-06-23T13:22:50.420265Z",
+                          "version": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                          "shortVersion": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                          "ref": "perf/source-maps-test"
+                        },
+                        {
+                          "dateReleased": "2020-06-17T19:21:02.186004Z",
+                          "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                          "dateCreated": "2020-06-17T18:45:31.042157Z",
+                          "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                          "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                          "ref": "master"
+                        }
+                      ],
+                      "dateCreated": "2020-06-17T18:43:37Z",
+                      "message": "feat(billing): Get a lot of money",
+                      "id": "b65bc521378269d3eaefdc964f8ef56621414943"
+                    },
+                    "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                    "authors": [
+                      {
+                        "username": "a37a1b4520ce46cea147ae2885a4e7e7",
+                        "lastLogin": "2020-09-14T22:34:55.550640Z",
+                        "isSuperuser": false,
+                        "isManaged": false,
+                        "experiments": {},
+                        "lastActive": "2020-09-15T22:13:20.503880Z",
+                        "isStaff": false,
+                        "id": "655784",
+                        "isActive": true,
+                        "has2fa": false,
+                        "name": "hell.boy@sentry.io",
+                        "avatarUrl": "https://secure.gravatar.com/avatar/eaa22e25b3a984659420831a77e4874e?s=32&d=mm",
+                        "dateJoined": "2020-04-20T16:21:25.365772Z",
+                        "emails": [
+                          {
+                            "is_verified": false,
+                            "id": "784574",
+                            "email": "hellboy@gmail.com"
+                          },
+                          {
+                            "is_verified": true,
+                            "id": "749185",
+                            "email": "hell.boy@sentry.io"
+                          }
+                        ],
+                        "avatar": {
+                          "avatarUuid": null,
+                          "avatarType": "letter_avatar"
+                        },
+                        "hasPasswordAuth": false,
+                        "email": "hell.boy@sentry.io"
+                      }
+                    ],
+                    "owner": null,
+                    "ref": "master",
+                    "projects": [
+                      {
+                        "name": "Sentry CSP",
+                        "slug": "sentry-csp"
+                      },
+                      {
+                        "name": "Backend",
+                        "slug": "sentry"
+                      },
+                      {
+                        "name": "Frontend",
+                        "slug": "javascript"
+                      }
+                    ]
+                  },
+                  "groupID": "1341191803"
                 }
               }
             }
@@ -8337,6 +10421,600 @@
               "application/json": {
                 "schema": {
                   "type": "object"
+                },
+                "example": {
+                  "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+                  "dist": null,
+                  "userReport": null,
+                  "previousEventID": null,
+                  "message": "",
+                  "id": "9999aaafcc8b46d797c23c6077c6ff01",
+                  "size": 107762,
+                  "errors": [
+                    {
+                      "data": {
+                        "column": 8,
+                        "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                        "row": 15
+                      },
+                      "message": "Invalid location in sourcemap",
+                      "type": "js_invalid_sourcemap_location"
+                    }
+                  ],
+                  "platform": "javascript",
+                  "nextEventID": "99f9e199e9a74a14bfef6196ad741619",
+                  "type": "error",
+                  "metadata": {
+                    "type": "ForbiddenError",
+                    "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+                  },
+                  "tags": [
+                    {
+                      "value": "Chrome 83.0.4103",
+                      "key": "browser",
+                      "_meta": null
+                    },
+                    {
+                      "value": "Chrome",
+                      "key": "browser.name",
+                      "_meta": null
+                    },
+                    {
+                      "value": "prod",
+                      "key": "environment",
+                      "_meta": null
+                    },
+                    {
+                      "value": "yes",
+                      "key": "handled",
+                      "_meta": null
+                    },
+                    {
+                      "value": "error",
+                      "key": "level",
+                      "_meta": null
+                    },
+                    {
+                      "value": "generic",
+                      "key": "mechanism",
+                      "_meta": null
+                    }
+                  ],
+                  "dateCreated": "2020-06-17T22:26:56.098086Z",
+                  "dateReceived": "2020-06-17T22:26:56.428721Z",
+                  "user": {
+                    "username": null,
+                    "name": "Hell Boy",
+                    "ip_address": "192.168.1.1",
+                    "email": "hell@boy.cat",
+                    "data": {
+                      "isStaff": false
+                    },
+                    "id": "550747"
+                  },
+                  "entries": [
+                    {
+                      "type": "exception",
+                      "data": {
+                        "values": [
+                          {
+                            "stacktrace": {
+                              "frames": [
+                                {
+                                  "function": "ignoreOnError",
+                                  "errors": null,
+                                  "colNo": 23,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "inApp": false,
+                                  "lineNo": 71,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      66,
+                                      "            }"
+                                    ],
+                                    [
+                                      67,
+                                      "            // Attempt to invoke user-land function"
+                                    ],
+                                    [
+                                      68,
+                                      "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                    ],
+                                    [
+                                      69,
+                                      "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                    ],
+                                    [
+                                      70,
+                                      "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                    ],
+                                    [
+                                      71,
+                                      "            return fn.apply(this, wrappedArguments);"
+                                    ],
+                                    [
+                                      72,
+                                      "            // tslint:enable:no-unsafe-any"
+                                    ],
+                                    [
+                                      73,
+                                      "        }"
+                                    ],
+                                    [
+                                      74,
+                                      "        catch (ex) {"
+                                    ],
+                                    [
+                                      75,
+                                      "            ignoreNextOnError();"
+                                    ],
+                                    [
+                                      76,
+                                      "            withScope(function (scope) {"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": "apply",
+                                  "errors": null,
+                                  "colNo": 24,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "inApp": false,
+                                  "lineNo": 74,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      69,
+                                      "     */"
+                                    ],
+                                    [
+                                      70,
+                                      "    triggerAsync: function triggerAsync() {"
+                                    ],
+                                    [
+                                      71,
+                                      "        var args = arguments,"
+                                    ],
+                                    [
+                                      72,
+                                      "            me = this;"
+                                    ],
+                                    [
+                                      73,
+                                      "        _.nextTick(function () {"
+                                    ],
+                                    [
+                                      74,
+                                      "            me.trigger.apply(me, args);"
+                                    ],
+                                    [
+                                      75,
+                                      "        });"
+                                    ],
+                                    [
+                                      76,
+                                      "    },"
+                                    ],
+                                    [
+                                      77,
+                                      ""
+                                    ],
+                                    [
+                                      78,
+                                      "    /**"
+                                    ],
+                                    [
+                                      79,
+                                      "     * Wraps the trigger mechanism with a deferral function."
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "module": null,
+                            "rawStacktrace": {
+                              "frames": [
+                                {
+                                  "function": "a",
+                                  "errors": null,
+                                  "colNo": 88800,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 81,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      76,
+                                      "/*!"
+                                    ],
+                                    [
+                                      77,
+                                      "  Copyright (c) 2018 Jed Watson."
+                                    ],
+                                    [
+                                      78,
+                                      "  Licensed under the MIT License (MIT), see"
+                                    ],
+                                    [
+                                      79,
+                                      "  http://jedwatson.github.io/react-select"
+                                    ],
+                                    [
+                                      80,
+                                      "*/"
+                                    ],
+                                    [
+                                      81,
+                                      "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                    ],
+                                    [
+                                      82,
+                                      "/*!"
+                                    ],
+                                    [
+                                      83,
+                                      " * JavaScript Cookie v2.2.1"
+                                    ],
+                                    [
+                                      84,
+                                      " * https://github.com/js-cookie/js-cookie"
+                                    ],
+                                    [
+                                      85,
+                                      " *"
+                                    ],
+                                    [
+                                      86,
+                                      " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": null,
+                                  "errors": null,
+                                  "colNo": 149484,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 119,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      114,
+                                      "/* @license"
+                                    ],
+                                    [
+                                      115,
+                                      "Papa Parse"
+                                    ],
+                                    [
+                                      116,
+                                      "v5.2.0"
+                                    ],
+                                    [
+                                      117,
+                                      "https://github.com/mholt/PapaParse"
+                                    ],
+                                    [
+                                      118,
+                                      "License: MIT"
+                                    ],
+                                    [
+                                      119,
+                                      "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                    ],
+                                    [
+                                      120,
+                                      "/**!"
+                                    ],
+                                    [
+                                      121,
+                                      " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                    ],
+                                    [
+                                      122,
+                                      " * @version 1.16.1"
+                                    ],
+                                    [
+                                      123,
+                                      " * @license"
+                                    ],
+                                    [
+                                      124,
+                                      " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "mechanism": {
+                              "type": "generic",
+                              "handled": true
+                            },
+                            "threadId": null,
+                            "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                            "type": "ForbiddenError"
+                          }
+                        ],
+                        "excOmitted": null,
+                        "hasSystemFrames": true
+                      }
+                    },
+                    {
+                      "type": "breadcrumbs",
+                      "data": {
+                        "values": [
+                          {
+                            "category": "tracing",
+                            "level": "debug",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.266586Z",
+                            "data": null,
+                            "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                            "type": "debug"
+                          },
+                          {
+                            "category": "xhr",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.619446Z",
+                            "data": {
+                              "url": "/api/0/internal/health/",
+                              "status_code": 200,
+                              "method": "GET"
+                            },
+                            "message": null,
+                            "type": "http"
+                          },
+                          {
+                            "category": "sentry.transaction",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.945016Z",
+                            "data": null,
+                            "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                            "type": "default"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "request",
+                      "data": {
+                        "fragment": null,
+                        "cookies": [],
+                        "inferredContentType": null,
+                        "env": null,
+                        "headers": [
+                          [
+                            "User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                          ]
+                        ],
+                        "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                        "query": [
+                          [
+                            "project",
+                            "5236886"
+                          ]
+                        ],
+                        "data": null,
+                        "method": null
+                      }
+                    }
+                  ],
+                  "packages": {},
+                  "sdk": {
+                    "version": "5.17.0",
+                    "name": "sentry.javascript.browser"
+                  },
+                  "_meta": {
+                    "user": null,
+                    "context": null,
+                    "entries": {},
+                    "contexts": null,
+                    "message": null,
+                    "packages": null,
+                    "tags": {},
+                    "sdk": null
+                  },
+                  "contexts": {
+                    "ForbiddenError": {
+                      "status": 403,
+                      "statusText": "Forbidden",
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "type": "default"
+                    },
+                    "browser": {
+                      "version": "83.0.4103",
+                      "type": "browser",
+                      "name": "Chrome"
+                    },
+                    "os": {
+                      "version": "10",
+                      "type": "os",
+                      "name": "Windows"
+                    },
+                    "trace": {
+                      "span_id": "83db1ad17e67dfe7",
+                      "type": "trace",
+                      "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                      "op": "navigation"
+                    },
+                    "organization": {
+                      "type": "default",
+                      "id": "323938",
+                      "slug": "hellboy-meowmeow"
+                    }
+                  },
+                  "fingerprints": [
+                    "fbe908cc63d63ea9763fd84cb6bad177"
+                  ],
+                  "context": {
+                    "resp": {
+                      "status": 403,
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "name": "ForbiddenError",
+                      "statusText": "Forbidden",
+                      "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                      "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                    }
+                  },
+                  "release": {
+                    "dateReleased": "2020-06-17T19:21:02.186004Z",
+                    "newGroups": 4,
+                    "commitCount": 11,
+                    "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                    "data": {},
+                    "lastDeploy": {
+                      "name": "b65bc521378269d3eaefdc964f8ef56621414943 to prod",
+                      "url": null,
+                      "environment": "prod",
+                      "dateStarted": null,
+                      "dateFinished": "2020-06-17T19:20:55.641748Z",
+                      "id": "6883490"
+                    },
+                    "deployCount": 1,
+                    "dateCreated": "2020-06-17T18:45:31.042157Z",
+                    "lastEvent": "2020-07-08T21:21:21Z",
+                    "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                    "firstEvent": "2020-06-17T22:25:14Z",
+                    "lastCommit": {
+                      "repository": {
+                        "status": "active",
+                        "integrationId": "2933",
+                        "externalSlug": "getsentry/getsentry",
+                        "name": "getsentry/getsentry",
+                        "provider": {
+                          "id": "integrations:github",
+                          "name": "GitHub"
+                        },
+                        "url": "https://github.com/getsentry/getsentry",
+                        "id": "2",
+                        "dateCreated": "2016-10-10T21:36:45.373994Z"
+                      },
+                      "releases": [
+                        {
+                          "dateReleased": "2020-06-23T13:26:18.427090Z",
+                          "url": "https://freight.getsentry.net/deploys/getsentry/staging/2077/",
+                          "dateCreated": "2020-06-23T13:22:50.420265Z",
+                          "version": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                          "shortVersion": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                          "ref": "perf/source-maps-test"
+                        },
+                        {
+                          "dateReleased": "2020-06-17T19:21:02.186004Z",
+                          "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                          "dateCreated": "2020-06-17T18:45:31.042157Z",
+                          "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                          "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                          "ref": "master"
+                        }
+                      ],
+                      "dateCreated": "2020-06-17T18:43:37Z",
+                      "message": "feat(billing): Get a lot of money",
+                      "id": "b65bc521378269d3eaefdc964f8ef56621414943"
+                    },
+                    "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                    "authors": [
+                      {
+                        "username": "a37a1b4520ce46cea147ae2885a4e7e7",
+                        "lastLogin": "2020-09-14T22:34:55.550640Z",
+                        "isSuperuser": false,
+                        "isManaged": false,
+                        "experiments": {},
+                        "lastActive": "2020-09-15T22:13:20.503880Z",
+                        "isStaff": false,
+                        "id": "655784",
+                        "isActive": true,
+                        "has2fa": false,
+                        "name": "hell.boy@sentry.io",
+                        "avatarUrl": "https://secure.gravatar.com/avatar/eaa22e25b3a984659420831a77e4874e?s=32&d=mm",
+                        "dateJoined": "2020-04-20T16:21:25.365772Z",
+                        "emails": [
+                          {
+                            "is_verified": false,
+                            "id": "784574",
+                            "email": "hellboy@gmail.com"
+                          },
+                          {
+                            "is_verified": true,
+                            "id": "749185",
+                            "email": "hell.boy@sentry.io"
+                          }
+                        ],
+                        "avatar": {
+                          "avatarUuid": null,
+                          "avatarType": "letter_avatar"
+                        },
+                        "hasPasswordAuth": false,
+                        "email": "hell.boy@sentry.io"
+                      }
+                    ],
+                    "owner": null,
+                    "ref": "master",
+                    "projects": [
+                      {
+                        "name": "Sentry CSP",
+                        "slug": "sentry-csp"
+                      },
+                      {
+                        "name": "Backend",
+                        "slug": "sentry"
+                      },
+                      {
+                        "name": "Frontend",
+                        "slug": "javascript"
+                      }
+                    ]
+                  },
+                  "groupID": "1341191803"
                 }
               }
             }
@@ -8390,7 +11068,53 @@
                   "items": {
                     "type": "object"
                   }
-                }
+                },
+                "example": [
+                  {
+                    "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",
+                    "tags": [
+                      {
+                        "key": "browser",
+                        "value": "Chrome 60.0"
+                      },
+                      {
+                        "key": "device",
+                        "value": "Other"
+                      },
+                      {
+                        "key": "environment",
+                        "value": "production"
+                      },
+                      {
+                        "value": "fatal",
+                        "key": "level"
+                      },
+                      {
+                        "key": "os",
+                        "value": "Mac OS X 10.12.6"
+                      },
+                      {
+                        "value": "CPython 2.7.16",
+                        "key": "runtime"
+                      },
+                      {
+                        "key": "release",
+                        "value": "17642328ead24b51867165985996d04b29310337"
+                      },
+                      {
+                        "key": "server_name",
+                        "value": "web1.example.com"
+                      }
+                    ],
+                    "dateCreated": "2020-09-11T17:46:36Z",
+                    "user": null,
+                    "message": "This is an example Python exception",
+                    "id": "dfb1a2d057194e76a4186cc8a5271553",
+                    "platform": "python",
+                    "event.type": "error",
+                    "groupID": "1889724436"
+                  }
+                ]
               }
             }
           },
@@ -9394,6 +12118,2394 @@
           {
             "auth_token": [
               "event:admin"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/organizations/{organization_slug}/releases/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Return a list of releases for a given organization.",
+        "operationId": "List an Organization's Releases",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "This parameter can be used to create a \"starts with\" filter for the version.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "authors",
+                      "commitCount",
+                      "data",
+                      "dateCreated",
+                      "dateReleased",
+                      "deployCount",
+                      "firstEvent",
+                      "lastCommit",
+                      "lastDeploy",
+                      "lastEvent",
+                      "newGroups",
+                      "owner",
+                      "projects",
+                      "ref",
+                      "shortVersion",
+                      "version",
+                      "url"
+                    ],
+                    "properties": {
+                      "authors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "commitCount": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "data": {
+                        "type": "object"
+                      },
+                      "dateCreated": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "dateReleased": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "deployCount": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "firstEvent": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "lastCommit": {
+                        "type": "object",
+                        "nullable": true
+                      },
+                      "lastDeploy": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "lastEvent": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "newGroups": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "owner": {
+                        "type": "object",
+                        "nullable": true
+                      },
+                      "projects": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "slug": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "ref": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "shortVersion": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "authors": [],
+                    "commitCount": 0,
+                    "data": {},
+                    "dateCreated": "2018-11-06T21:20:08.033Z",
+                    "dateReleased": null,
+                    "deployCount": 0,
+                    "firstEvent": null,
+                    "lastCommit": null,
+                    "lastDeploy": null,
+                    "lastEvent": null,
+                    "newGroups": 0,
+                    "owner": null,
+                    "projects": [
+                      {
+                        "name": "Pump Station",
+                        "slug": "pump-station"
+                      }
+                    ],
+                    "ref": "6ba09a7c53235ee8a8fa5ee4c1ca8ca886e7fdbb",
+                    "shortVersion": "2.0rc2",
+                    "url": null,
+                    "version": "2.0rc2"
+                  },
+                  {
+                    "authors": [],
+                    "commitCount": 0,
+                    "data": {},
+                    "dateCreated": "2018-11-06T21:19:58.559Z",
+                    "dateReleased": null,
+                    "deployCount": 0,
+                    "firstEvent": "2018-11-06T21:19:58.639Z",
+                    "lastCommit": null,
+                    "lastDeploy": null,
+                    "lastEvent": "2018-11-06T21:19:58.639Z",
+                    "newGroups": 0,
+                    "owner": null,
+                    "projects": [
+                      {
+                        "name": "Prime Mover",
+                        "slug": "prime-mover"
+                      }
+                    ],
+                    "ref": null,
+                    "shortVersion": "2b6af31",
+                    "url": null,
+                    "version": "2b6af31b2edccc73a629108b17344dfe20858780"
+                  }
+                ]
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Create a new release for the given Organization.  Releases are used by\nSentry to improve its error reporting abilities by correlating\nfirst seen events with the release that might have introduced the\nproblem.\nReleases are also necessary for sourcemaps and other debug features\nthat require manual upload for functioning well.",
+        "operationId": "Create a New Release for an Organization.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "version",
+                  "projects"
+                ],
+                "properties": {
+                  "version": {
+                    "type": "string",
+                    "description": "A version identifier for this release. Can be a version number, a commit hash etc."
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "An optional commit reference. This is useful if a tagged version has been provided."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "A URL that points to the release. This can be the path to an online interface to the sourcecode for instance"
+                  },
+                  "projects": {
+                    "type": "array",
+                    "description": "A list of project slugs that are involved in this release.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "dateReleased": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "An optional date that indicates when the release went live. If not provided the current time is assumed."
+                  },
+                  "commits": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "patch_set": {
+                          "type": "array",
+                          "description": "A list of the files that have been changed in the commit. Specifying the patch_set is necessary to power suspect commits and suggested assignees.",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "path",
+                              "type"
+                            ],
+                            "properties": {
+                              "path": {
+                                "type": "string",
+                                "description": "The path to the file. Both forward and backward slashes are supported."
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "A",
+                                  "M",
+                                  "D"
+                                ],
+                                "description": "The type of change that happened in the commit."
+                              }
+                            }
+                          }
+                        },
+                        "repository": {
+                          "type": "string",
+                          "description": "The full name of the repository the commit belongs to. If this field is not given Sentry will generate a name in the form: u'organization-<organization_id>' (i.e. if the organization id is 123, then the generated repository name will be u'organization-123)."
+                        },
+                        "author_name": {
+                          "type": "string",
+                          "description": "The name of the commit author."
+                        },
+                        "author_email": {
+                          "type": "string",
+                          "description": "The email of the commit author. The commit author's email is required to enable the suggested assignee feature."
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "The commit timestamp is used to sort the commits given. If a timestamp is not included, the commits will remain sorted in the order given."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "The commit message."
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "The commit id (the commit sha)."
+                        }
+                      }
+                    },
+                    "description": "An optional list of commit data to be associated with the release. Commits must include parameters `id` (the sha of the commit), and can optionally include `repository`, `message`, `patch_set`, `author_name`, `author_email`, and `timestamp`."
+                  },
+                  "refs": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "repository": {
+                          "type": "string",
+                          "description": "The full name of the repository the commit belongs to."
+                        },
+                        "commit": {
+                          "type": "string",
+                          "description": "The current release's commit."
+                        },
+                        "previousCommit": {
+                          "type": "string",
+                          "description": "The previous release's commit."
+                        }
+                      }
+                    },
+                    "description": "An optional way to indicate the start and end commits for each repository included in a release. Head commits must include parameters `repository` and `commit` (the HEAD sha). They can optionally include `previousCommit` (the sha of the HEAD of the previous release), which should be specified if this is the first time you've sent commit data. `commit` may contain a range in the form of `previousCommit..commit`."
+                  }
+                }
+              },
+              "example": {
+                "version": "2.0rc2",
+                "ref": "6ba09a7c53235ee8a8fa5ee4c1ca8ca886e7fdbb",
+                "projects": [
+                  "pump-station"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "authors",
+                    "commitCount",
+                    "data",
+                    "dateCreated",
+                    "dateReleased",
+                    "deployCount",
+                    "firstEvent",
+                    "lastCommit",
+                    "lastDeploy",
+                    "lastEvent",
+                    "newGroups",
+                    "owner",
+                    "projects",
+                    "ref",
+                    "shortVersion",
+                    "version",
+                    "url"
+                  ],
+                  "properties": {
+                    "authors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "commitCount": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "data": {
+                      "type": "object"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "dateReleased": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "deployCount": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "firstEvent": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastCommit": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "lastDeploy": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastEvent": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "newGroups": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "owner": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "projects": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "ref": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "shortVersion": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "authors": [],
+                  "commitCount": 0,
+                  "data": {},
+                  "dateCreated": "2019-01-03T00:12:55.109Z",
+                  "dateReleased": null,
+                  "deployCount": 0,
+                  "firstEvent": null,
+                  "lastCommit": null,
+                  "lastDeploy": null,
+                  "lastEvent": null,
+                  "newGroups": 0,
+                  "owner": null,
+                  "projects": [
+                    {
+                      "name": "Pump Station",
+                      "slug": "pump-station"
+                    }
+                  ],
+                  "ref": "6ba09a7c53235ee8a8fa5ee4c1ca8ca886e7fdbb",
+                  "shortVersion": "2.0rc2",
+                  "url": null,
+                  "version": "2.0rc2"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/organizations/{organization_slug}/releases/{version}/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Return a release for a given organization.",
+        "operationId": "Retrieve an Organization's Releases",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "authors",
+                    "commitCount",
+                    "data",
+                    "dateCreated",
+                    "dateReleased",
+                    "deployCount",
+                    "firstEvent",
+                    "lastCommit",
+                    "lastDeploy",
+                    "lastEvent",
+                    "newGroups",
+                    "owner",
+                    "projects",
+                    "ref",
+                    "shortVersion",
+                    "version",
+                    "url"
+                  ],
+                  "properties": {
+                    "authors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "commitCount": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "data": {
+                      "type": "object"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "dateReleased": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "deployCount": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "firstEvent": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastCommit": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "lastDeploy": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastEvent": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "newGroups": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "owner": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "projects": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "ref": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "shortVersion": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "authors": [],
+                  "commitCount": 0,
+                  "data": {},
+                  "dateCreated": "2018-11-06T21:20:08.033Z",
+                  "dateReleased": null,
+                  "deployCount": 0,
+                  "firstEvent": null,
+                  "lastCommit": null,
+                  "lastDeploy": null,
+                  "lastEvent": null,
+                  "newGroups": 0,
+                  "owner": null,
+                  "projects": [
+                    {
+                      "name": "Pump Station",
+                      "slug": "pump-station"
+                    }
+                  ],
+                  "ref": "6ba09a7c53235ee8a8fa5ee4c1ca8ca886e7fdbb",
+                  "shortVersion": "2.0rc2",
+                  "url": null,
+                  "version": "2.0rc2"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Update a release for a give organization.",
+        "operationId": "Update an Organization's Release.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ref": {
+                    "type": "string",
+                    "description": "An optional commit reference. This is useful if a tagged version has been provided."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "A URL that points to the release. This can be the path to an online interface to the sourcecode for instance."
+                  },
+                  "dateReleased": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "An optional date that indicates when the release went live. If not provided the current time is assumed."
+                  },
+                  "commits": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "description": "An optional list of commit data to be associated with the release. Commits must include parameters `id` (the sha of the commit), and can optionally include `repository`, `message`, `author_name`, `author_email`, and `timestamp`."
+                  },
+                  "refs": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "description": "An optional way to indicate the start and end commits for each repository included in a release. Head commits must include parameters `repository` and `commit` (the HEAD sha). They can optionally include `previousCommit` (the sha of the HEAD of the previous release), which should be specified if this is the first time you've sent commit data."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "authors",
+                    "commitCount",
+                    "data",
+                    "dateCreated",
+                    "dateReleased",
+                    "deployCount",
+                    "firstEvent",
+                    "lastCommit",
+                    "lastDeploy",
+                    "lastEvent",
+                    "newGroups",
+                    "owner",
+                    "projects",
+                    "ref",
+                    "shortVersion",
+                    "version",
+                    "url"
+                  ],
+                  "properties": {
+                    "authors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "commitCount": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "data": {
+                      "type": "object"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "dateReleased": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "deployCount": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "firstEvent": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastCommit": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "lastDeploy": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lastEvent": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "newGroups": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "owner": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "projects": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "ref": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "shortVersion": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "authors": [],
+                  "commitCount": 0,
+                  "data": {},
+                  "dateCreated": "2019-01-03T00:12:55.109Z",
+                  "dateReleased": null,
+                  "deployCount": 0,
+                  "firstEvent": null,
+                  "lastCommit": null,
+                  "lastDeploy": null,
+                  "lastEvent": null,
+                  "newGroups": 0,
+                  "owner": null,
+                  "projects": [
+                    {
+                      "name": "Pump Station",
+                      "slug": "pump-station"
+                    }
+                  ],
+                  "ref": "6ba09a7c53235ee8a8fa5ee4c1ca8ca886e7fdbb",
+                  "shortVersion": "2.0rc2",
+                  "url": null,
+                  "version": "2.0rc2"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Delete a release for a given organization.",
+        "operationId": "Delete an Organization's Release.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/organizations/{organization_slug}/releases/{version}/files/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Return a list of files for a given release.",
+        "operationId": "List an Organization's Release Files",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "sha1",
+                      "dist",
+                      "name",
+                      "dateCreated",
+                      "headers",
+                      "id",
+                      "size"
+                    ],
+                    "properties": {
+                      "sha1": {
+                        "type": "string"
+                      },
+                      "dist": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "dateCreated": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "headers": {
+                        "type": "object"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "size": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "dateCreated": "2018-11-06T21:20:22.894Z",
+                    "dist": null,
+                    "headers": {
+                      "Content-Type": "text/plain; encoding=utf-8"
+                    },
+                    "id": "3",
+                    "name": "/demo/goodbye.txt",
+                    "sha1": "94d6b21e962a9fc65889617ec1f17a1e2fe11b65",
+                    "size": 15
+                  }
+                ]
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Upload a new organization release file.",
+        "operationId": "Upload a New Organization Release File.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name (full path) of the file."
+                  },
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "The multipart encoded file."
+                  },
+                  "dist": {
+                    "type": "string",
+                    "description": "The name of the dist"
+                  },
+                  "header": {
+                    "type": "string",
+                    "description": "This parameter can be supplied multiple times to attach headers to the file. Each header is a string in the format `key:value`. For instance it can be used to define a content type."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success."
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/projects/{organization_slug}/{project_slug}/releases/{version}/files/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Return a list of files for a given release.",
+        "operationId": "List an Project's Release Files",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_slug",
+            "in": "path",
+            "description": "The slug of the project.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "sha1",
+                      "dist",
+                      "name",
+                      "dateCreated",
+                      "headers",
+                      "id",
+                      "size"
+                    ],
+                    "properties": {
+                      "sha1": {
+                        "type": "string"
+                      },
+                      "dist": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "dateCreated": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "headers": {
+                        "type": "object"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "size": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "dateCreated": "2018-11-06T21:20:22.894Z",
+                    "dist": null,
+                    "headers": {
+                      "Content-Type": "text/plain; encoding=utf-8"
+                    },
+                    "id": "3",
+                    "name": "/demo/goodbye.txt",
+                    "sha1": "94d6b21e962a9fc65889617ec1f17a1e2fe11b65",
+                    "size": 15
+                  }
+                ]
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Upload a new project release file.",
+        "operationId": "Upload a New Project Release File.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_slug",
+            "in": "path",
+            "description": "The slug of the project.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name (full path) of the file."
+                  },
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "The multipart encoded file."
+                  },
+                  "dist": {
+                    "type": "string",
+                    "description": "The name of the dist"
+                  },
+                  "header": {
+                    "type": "string",
+                    "description": "This parameter can be supplied multiple times to attach headers to the file. Each header is a string in the format `key:value`. For instance it can be used to define a content type."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sha1",
+                    "dist",
+                    "name",
+                    "dateCreated",
+                    "headers",
+                    "id",
+                    "size"
+                  ],
+                  "properties": {
+                    "sha1": {
+                      "type": "string"
+                    },
+                    "dist": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "headers": {
+                      "type": "object"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "dateCreated": "2018-11-06T21:20:22.894Z",
+                  "dist": null,
+                  "headers": {
+                    "Content-Type": "text/plain; encoding=utf-8"
+                  },
+                  "id": "3",
+                  "name": "/demo/goodbye.txt",
+                  "sha1": "94d6b21e962a9fc65889617ec1f17a1e2fe11b65",
+                  "size": 15
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/organizations/{organization_slug}/releases/{version}/files/{file_id}/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Retrieve a file for a given release.",
+        "operationId": "Retrieve an Organization Release's File",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "description": "The ID of the file to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sha1",
+                    "dist",
+                    "name",
+                    "dateCreated",
+                    "headers",
+                    "id",
+                    "size"
+                  ],
+                  "properties": {
+                    "sha1": {
+                      "type": "string"
+                    },
+                    "dist": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "headers": {
+                      "type": "object"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "dateCreated": "2018-11-06T21:20:19.150Z",
+                  "dist": null,
+                  "headers": {
+                    "Content-Type": "text/plain; encoding=utf-8"
+                  },
+                  "id": "1",
+                  "name": "/demo/message-for-you.txt",
+                  "sha1": "2ef7bde608ce5404e97d5f042f95f89f1c232871",
+                  "size": 12
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Upload an organization release file.",
+        "operationId": "Update an Organization Release File.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "description": "The ID of the file to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "version",
+                  "projects"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The new name (full path) of the file."
+                  },
+                  "dist": {
+                    "type": "string",
+                    "description": "The new name of the dist"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sha1",
+                    "dist",
+                    "name",
+                    "dateCreated",
+                    "headers",
+                    "id",
+                    "size"
+                  ],
+                  "properties": {
+                    "sha1": {
+                      "type": "string"
+                    },
+                    "dist": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "headers": {
+                      "type": "object"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "dateCreated": "2018-11-06T21:20:22.894Z",
+                  "dist": null,
+                  "headers": {
+                    "Content-Type": "text/plain; encoding=utf-8"
+                  },
+                  "id": "3",
+                  "name": "/demo/goodbye.txt",
+                  "sha1": "94d6b21e962a9fc65889617ec1f17a1e2fe11b65",
+                  "size": 15
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Delete a file for a given release.",
+        "operationId": "Delete an Organization Release's File",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "description": "The ID of the file to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/projects/{organization_slug}/{project_slug}/releases/{version}/files/{file_id}/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Retrieve a file for a given release.",
+        "operationId": "Retrieve an Project Release's File",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_slug",
+            "in": "path",
+            "description": "The slug of the project.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the file to retrieve.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sha1",
+                    "dist",
+                    "name",
+                    "dateCreated",
+                    "headers",
+                    "id",
+                    "size"
+                  ],
+                  "properties": {
+                    "sha1": {
+                      "type": "string"
+                    },
+                    "dist": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "headers": {
+                      "type": "object"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "dateCreated": "2018-11-06T21:20:19.150Z",
+                  "dist": null,
+                  "headers": {
+                    "Content-Type": "text/plain; encoding=utf-8"
+                  },
+                  "id": "1",
+                  "name": "/demo/message-for-you.txt",
+                  "sha1": "2ef7bde608ce5404e97d5f042f95f89f1c232871",
+                  "size": 12
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Upload a project release file.",
+        "operationId": "Update a Project Release File.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_slug",
+            "in": "path",
+            "description": "The slug of the project.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "description": "The ID of the file to retrieve.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "version",
+                  "projects"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The new name (full path) of the file."
+                  },
+                  "dist": {
+                    "type": "string",
+                    "description": "The new name of the dist"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sha1",
+                    "dist",
+                    "name",
+                    "dateCreated",
+                    "headers",
+                    "id",
+                    "size"
+                  ],
+                  "properties": {
+                    "sha1": {
+                      "type": "string"
+                    },
+                    "dist": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "dateCreated": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "headers": {
+                      "type": "object"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "size": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "dateCreated": "2018-11-06T21:20:22.894Z",
+                  "dist": null,
+                  "headers": {
+                    "Content-Type": "text/plain; encoding=utf-8"
+                  },
+                  "id": "3",
+                  "name": "/demo/goodbye.txt",
+                  "sha1": "94d6b21e962a9fc65889617ec1f17a1e2fe11b65",
+                  "size": 15
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Delete a file for a given release.",
+        "operationId": "Delete an Project Release's File",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_slug",
+            "in": "path",
+            "description": "The slug of the project.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "description": "The ID of the file to delete.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/organizations/{organization_slug}/releases/{version}/commits/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "List an organization release's commits.",
+        "operationId": "List an Organization Release's Commits",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "dateCreated",
+                      "id",
+                      "message"
+                    ],
+                    "properties": {
+                      "dateCreated": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "dateCreated": "2018-11-06T21:19:58.536Z",
+                    "id": "acbafc639127fd89d10f474520104517ff1d709e",
+                    "message": "Initial commit from Create Next App"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/projects/{organization_slug}/{project_slug}/releases/{version}/commits/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "List an project release's commits.",
+        "operationId": "List an Project Release's Commits",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_slug",
+            "in": "path",
+            "description": "The slug of the project the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "dateCreated",
+                      "id",
+                      "message"
+                    ],
+                    "properties": {
+                      "dateCreated": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "dateCreated": "2018-11-06T21:19:58.536Z",
+                    "id": "acbafc639127fd89d10f474520104517ff1d709e",
+                    "message": "Initial commit from Create Next App"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/organizations/{organization_slug}/releases/{version}/commitfiles/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Retrieve files changed in a release's commits",
+        "operationId": "Retrieve Files Changed in a Release's Commits",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization the release belongs to.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/projects/{organization_slug}/{project_slug}/releases/{version}/resolved/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "List issues to be resolved in a particular release.",
+        "operationId": "List Issues to be Resolved in a Particular Release.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_slug",
+            "in": "path",
+            "description": "The slug of the project.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success."
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      }
+    },
+    "/api/0/organizations/{organization_slug}/releases/{version}/deploys/": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Return a list of deploys for a given release.",
+        "operationId": "List a Release's Deploys",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "environment",
+                      "name",
+                      "dateStarted",
+                      "dateFinished",
+                      "url",
+                      "id"
+                    ],
+                    "properties": {
+                      "environment": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "dateStarted": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "dateFinished": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "url": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "id": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "environment": "prod",
+                    "name": null,
+                    "url": null,
+                    "dateStarted": null,
+                    "dateFinished": "2020-08-31T19:40:38.651670Z",
+                    "id": "1234567"
+                  }
+                ]
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "description": "Create a Deploy.",
+        "operationId": "Create a New Deploy for an Organization.",
+        "parameters": [
+          {
+            "name": "organization_slug",
+            "in": "path",
+            "description": "The slug of the organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version identifier of the release.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "environment"
+                ],
+                "properties": {
+                  "environment": {
+                    "type": "string",
+                    "description": "The environment you're deploying to."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The optional url that points to the deploy."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The optional name of the deploy."
+                  },
+                  "dateStarted": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "An optional date that indicates when the deploy started."
+                  },
+                  "dateFinished": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "An optional date that indicates when the deploy ended. If not provided, the current time is used."
+                  }
+                }
+              },
+              "example": {
+                "environment": "prod"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "environment",
+                    "name",
+                    "dateStarted",
+                    "dateFinished",
+                    "url",
+                    "id"
+                  ],
+                  "properties": {
+                    "environment": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "dateStarted": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "dateFinished": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "url": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "id": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "environment": "prod",
+                  "name": null,
+                  "url": null,
+                  "dateStarted": null,
+                  "dateFinished": "2020-08-31T19:40:38.651670Z",
+                  "id": "1234567"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth_token": [
+              "project:releases"
             ]
           }
         ]

--- a/paths/events/issue-events.json
+++ b/paths/events/issue-events.json
@@ -34,7 +34,53 @@
               "items": {
                 "$ref": "../../components/schemas/event.json#/Event"
               }
-            }
+            },
+            "example": [
+              {
+                "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",
+                "tags": [
+                  {
+                    "key": "browser",
+                    "value": "Chrome 60.0"
+                  },
+                  {
+                    "key": "device",
+                    "value": "Other"
+                  },
+                  {
+                    "key": "environment",
+                    "value": "production"
+                  },
+                  {
+                    "value": "fatal",
+                    "key": "level"
+                  },
+                  {
+                    "key": "os",
+                    "value": "Mac OS X 10.12.6"
+                  },
+                  {
+                    "value": "CPython 2.7.16",
+                    "key": "runtime"
+                  },
+                  {
+                    "key": "release",
+                    "value": "17642328ead24b51867165985996d04b29310337"
+                  },
+                  {
+                    "key": "server_name",
+                    "value": "web1.example.com"
+                  }
+                ],
+                "dateCreated": "2020-09-11T17:46:36Z",
+                "user": null,
+                "message": "This is an example Python exception",
+                "id": "dfb1a2d057194e76a4186cc8a5271553",
+                "platform": "python",
+                "event.type": "error",
+                "groupID": "1889724436"
+              }
+            ]
           }
         }
       },

--- a/paths/events/issue-hashes.json
+++ b/paths/events/issue-hashes.json
@@ -27,7 +27,7 @@
                 "type": "object",
                 "properties": {
                   "latestEvent": {
-                      "$ref": "../../components/schemas/event.json#/EventDetailed"
+                    "$ref": "../../components/schemas/event.json#/Hash"
                   },
                   "id": {
                     "type": "string"
@@ -36,12 +36,500 @@
                     "type": "string",
                     "enum": [
                       "unlocked",
-                      "locked_in_migration",
+                      "locked_in_migration"
                     ]
                   }
                 }
               }
-            }
+            },
+            "example": [
+              {
+                "id": "dhgjkldfsghdfakjgh",
+                "latestEvent": {
+                  "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+                  "dist": null,
+                  "message": "",
+                  "id": "9999aaafcc8b46d797c23c6077c6ff01",
+                  "size": 107762,
+                  "errors": [
+                    {
+                      "data": {
+                        "column": 8,
+                        "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                        "row": 15
+                      },
+                      "message": "Invalid location in sourcemap",
+                      "type": "js_invalid_sourcemap_location"
+                    }
+                  ],
+                  "platform": "javascript",
+                  "type": "error",
+                  "metadata": {
+                    "type": "ForbiddenError",
+                    "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+                  },
+                  "tags": [
+                    {
+                      "value": "Chrome 83.0.4103",
+                      "key": "browser",
+                      "_meta": null
+                    },
+                    {
+                      "value": "Chrome",
+                      "key": "browser.name",
+                      "_meta": null
+                    },
+                    {
+                      "value": "prod",
+                      "key": "environment",
+                      "_meta": null
+                    },
+                    {
+                      "value": "yes",
+                      "key": "handled",
+                      "_meta": null
+                    },
+                    {
+                      "value": "error",
+                      "key": "level",
+                      "_meta": null
+                    },
+                    {
+                      "value": "generic",
+                      "key": "mechanism",
+                      "_meta": null
+                    }
+                  ],
+                  "dateCreated": "2020-06-17T22:26:56.098086Z",
+                  "dateReceived": "2020-06-17T22:26:56.428721Z",
+                  "user": {
+                    "username": null,
+                    "name": "Hell Boy",
+                    "ip_address": "192.168.1.1",
+                    "email": "hell@boy.cat",
+                    "data": {
+                      "isStaff": false
+                    },
+                    "id": "550747"
+                  },
+                  "entries": [
+                    {
+                      "type": "exception",
+                      "data": {
+                        "values": [
+                          {
+                            "stacktrace": {
+                              "frames": [
+                                {
+                                  "function": "ignoreOnError",
+                                  "errors": null,
+                                  "colNo": 23,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "inApp": false,
+                                  "lineNo": 71,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      66,
+                                      "            }"
+                                    ],
+                                    [
+                                      67,
+                                      "            // Attempt to invoke user-land function"
+                                    ],
+                                    [
+                                      68,
+                                      "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                    ],
+                                    [
+                                      69,
+                                      "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                    ],
+                                    [
+                                      70,
+                                      "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                    ],
+                                    [
+                                      71,
+                                      "            return fn.apply(this, wrappedArguments);"
+                                    ],
+                                    [
+                                      72,
+                                      "            // tslint:enable:no-unsafe-any"
+                                    ],
+                                    [
+                                      73,
+                                      "        }"
+                                    ],
+                                    [
+                                      74,
+                                      "        catch (ex) {"
+                                    ],
+                                    [
+                                      75,
+                                      "            ignoreNextOnError();"
+                                    ],
+                                    [
+                                      76,
+                                      "            withScope(function (scope) {"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": "apply",
+                                  "errors": null,
+                                  "colNo": 24,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "inApp": false,
+                                  "lineNo": 74,
+                                  "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                                  "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      69,
+                                      "     */"
+                                    ],
+                                    [
+                                      70,
+                                      "    triggerAsync: function triggerAsync() {"
+                                    ],
+                                    [
+                                      71,
+                                      "        var args = arguments,"
+                                    ],
+                                    [
+                                      72,
+                                      "            me = this;"
+                                    ],
+                                    [
+                                      73,
+                                      "        _.nextTick(function () {"
+                                    ],
+                                    [
+                                      74,
+                                      "            me.trigger.apply(me, args);"
+                                    ],
+                                    [
+                                      75,
+                                      "        });"
+                                    ],
+                                    [
+                                      76,
+                                      "    },"
+                                    ],
+                                    [
+                                      77,
+                                      ""
+                                    ],
+                                    [
+                                      78,
+                                      "    /**"
+                                    ],
+                                    [
+                                      79,
+                                      "     * Wraps the trigger mechanism with a deferral function."
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "module": null,
+                            "rawStacktrace": {
+                              "frames": [
+                                {
+                                  "function": "a",
+                                  "errors": null,
+                                  "colNo": 88800,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 81,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      76,
+                                      "/*!"
+                                    ],
+                                    [
+                                      77,
+                                      "  Copyright (c) 2018 Jed Watson."
+                                    ],
+                                    [
+                                      78,
+                                      "  Licensed under the MIT License (MIT), see"
+                                    ],
+                                    [
+                                      79,
+                                      "  http://jedwatson.github.io/react-select"
+                                    ],
+                                    [
+                                      80,
+                                      "*/"
+                                    ],
+                                    [
+                                      81,
+                                      "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                    ],
+                                    [
+                                      82,
+                                      "/*!"
+                                    ],
+                                    [
+                                      83,
+                                      " * JavaScript Cookie v2.2.1"
+                                    ],
+                                    [
+                                      84,
+                                      " * https://github.com/js-cookie/js-cookie"
+                                    ],
+                                    [
+                                      85,
+                                      " *"
+                                    ],
+                                    [
+                                      86,
+                                      " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                },
+                                {
+                                  "function": null,
+                                  "errors": null,
+                                  "colNo": 149484,
+                                  "vars": null,
+                                  "package": null,
+                                  "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "inApp": false,
+                                  "lineNo": 119,
+                                  "module": null,
+                                  "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                                  "platform": null,
+                                  "instructionAddr": null,
+                                  "context": [
+                                    [
+                                      114,
+                                      "/* @license"
+                                    ],
+                                    [
+                                      115,
+                                      "Papa Parse"
+                                    ],
+                                    [
+                                      116,
+                                      "v5.2.0"
+                                    ],
+                                    [
+                                      117,
+                                      "https://github.com/mholt/PapaParse"
+                                    ],
+                                    [
+                                      118,
+                                      "License: MIT"
+                                    ],
+                                    [
+                                      119,
+                                      "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                    ],
+                                    [
+                                      120,
+                                      "/**!"
+                                    ],
+                                    [
+                                      121,
+                                      " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                    ],
+                                    [
+                                      122,
+                                      " * @version 1.16.1"
+                                    ],
+                                    [
+                                      123,
+                                      " * @license"
+                                    ],
+                                    [
+                                      124,
+                                      " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                    ]
+                                  ],
+                                  "symbolAddr": null,
+                                  "trust": null,
+                                  "symbol": null,
+                                  "rawFunction": null
+                                }
+                              ],
+                              "framesOmitted": null,
+                              "registers": null,
+                              "hasSystemFrames": true
+                            },
+                            "mechanism": {
+                              "type": "generic",
+                              "handled": true
+                            },
+                            "threadId": null,
+                            "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                            "type": "ForbiddenError"
+                          }
+                        ],
+                        "excOmitted": null,
+                        "hasSystemFrames": true
+                      }
+                    },
+                    {
+                      "type": "breadcrumbs",
+                      "data": {
+                        "values": [
+                          {
+                            "category": "tracing",
+                            "level": "debug",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.266586Z",
+                            "data": null,
+                            "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                            "type": "debug"
+                          },
+                          {
+                            "category": "xhr",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.619446Z",
+                            "data": {
+                              "url": "/api/0/internal/health/",
+                              "status_code": 200,
+                              "method": "GET"
+                            },
+                            "message": null,
+                            "type": "http"
+                          },
+                          {
+                            "category": "sentry.transaction",
+                            "level": "info",
+                            "event_id": null,
+                            "timestamp": "2020-06-17T22:26:55.945016Z",
+                            "data": null,
+                            "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                            "type": "default"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "request",
+                      "data": {
+                        "fragment": null,
+                        "cookies": [],
+                        "inferredContentType": null,
+                        "env": null,
+                        "headers": [
+                          [
+                            "User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                          ]
+                        ],
+                        "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                        "query": [
+                          [
+                            "project",
+                            "5236886"
+                          ]
+                        ],
+                        "data": null,
+                        "method": null
+                      }
+                    }
+                  ],
+                  "packages": {},
+                  "sdk": {
+                    "version": "5.17.0",
+                    "name": "sentry.javascript.browser"
+                  },
+                  "_meta": {
+                    "user": null,
+                    "context": null,
+                    "entries": {},
+                    "contexts": null,
+                    "message": null,
+                    "packages": null,
+                    "tags": {},
+                    "sdk": null
+                  },
+                  "contexts": {
+                    "ForbiddenError": {
+                      "status": 403,
+                      "statusText": "Forbidden",
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "type": "default"
+                    },
+                    "browser": {
+                      "version": "83.0.4103",
+                      "type": "browser",
+                      "name": "Chrome"
+                    },
+                    "os": {
+                      "version": "10",
+                      "type": "os",
+                      "name": "Windows"
+                    },
+                    "trace": {
+                      "span_id": "83db1ad17e67dfe7",
+                      "type": "trace",
+                      "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                      "op": "navigation"
+                    },
+                    "organization": {
+                      "type": "default",
+                      "id": "323938",
+                      "slug": "hellboy-meowmeow"
+                    }
+                  },
+                  "fingerprints": [
+                    "fbe908cc63d63ea9763fd84cb6bad177"
+                  ],
+                  "context": {
+                    "resp": {
+                      "status": 403,
+                      "responseJSON": {
+                        "detail": "You do not have permission to perform this action."
+                      },
+                      "name": "ForbiddenError",
+                      "statusText": "Forbidden",
+                      "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                      "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                    }
+                  },
+                  "groupID": "1341191803"
+                }
+              }
+            ]
           }
         }
       },

--- a/paths/events/issue-hashes.json
+++ b/paths/events/issue-hashes.json
@@ -182,7 +182,6 @@
                                   "symbolAddr": null,
                                   "trust": null,
                                   "symbol": null,
-                                  "rawFunction": null
                                 },
                                 {
                                   "function": "apply",
@@ -246,7 +245,6 @@
                                   "symbolAddr": null,
                                   "trust": null,
                                   "symbol": null,
-                                  "rawFunction": null
                                 }
                               ],
                               "framesOmitted": null,
@@ -318,7 +316,6 @@
                                   "symbolAddr": null,
                                   "trust": null,
                                   "symbol": null,
-                                  "rawFunction": null
                                 },
                                 {
                                   "function": null,
@@ -382,7 +379,6 @@
                                   "symbolAddr": null,
                                   "trust": null,
                                   "symbol": null,
-                                  "rawFunction": null
                                 }
                               ],
                               "framesOmitted": null,

--- a/paths/events/latest-event.json
+++ b/paths/events/latest-event.json
@@ -164,7 +164,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             },
                             {
                               "function": "apply",
@@ -228,7 +227,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             }
                           ],
                           "framesOmitted": null,
@@ -300,7 +298,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             },
                             {
                               "function": null,
@@ -364,7 +361,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             }
                           ],
                           "framesOmitted": null,

--- a/paths/events/latest-event.json
+++ b/paths/events/latest-event.json
@@ -22,7 +22,601 @@
         "content": {
           "application/json": {
             "schema": {
-                "$ref": "../../components/schemas/event.json#/EventDetailed"
+              "$ref": "../../components/schemas/event.json#/EventDetailed"
+            },
+            "example": {
+              "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+              "dist": null,
+              "userReport": null,
+              "previousEventID": null,
+              "message": "",
+              "id": "9999aaafcc8b46d797c23c6077c6ff01",
+              "size": 107762,
+              "errors": [
+                {
+                  "data": {
+                    "column": 8,
+                    "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                    "row": 15
+                  },
+                  "message": "Invalid location in sourcemap",
+                  "type": "js_invalid_sourcemap_location"
+                }
+              ],
+              "platform": "javascript",
+              "nextEventID": "99f9e199e9a74a14bfef6196ad741619",
+              "type": "error",
+              "metadata": {
+                "type": "ForbiddenError",
+                "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+              },
+              "tags": [
+                {
+                  "value": "Chrome 83.0.4103",
+                  "key": "browser",
+                  "_meta": null
+                },
+                {
+                  "value": "Chrome",
+                  "key": "browser.name",
+                  "_meta": null
+                },
+                {
+                  "value": "prod",
+                  "key": "environment",
+                  "_meta": null
+                },
+                {
+                  "value": "yes",
+                  "key": "handled",
+                  "_meta": null
+                },
+                {
+                  "value": "error",
+                  "key": "level",
+                  "_meta": null
+                },
+                {
+                  "value": "generic",
+                  "key": "mechanism",
+                  "_meta": null
+                }
+              ],
+              "dateCreated": "2020-06-17T22:26:56.098086Z",
+              "dateReceived": "2020-06-17T22:26:56.428721Z",
+              "user": {
+                "username": null,
+                "name": "Hell Boy",
+                "ip_address": "192.168.1.1",
+                "email": "hell@boy.cat",
+                "data": {
+                  "isStaff": false
+                },
+                "id": "550747"
+              },
+              "entries": [
+                {
+                  "type": "exception",
+                  "data": {
+                    "values": [
+                      {
+                        "stacktrace": {
+                          "frames": [
+                            {
+                              "function": "ignoreOnError",
+                              "errors": null,
+                              "colNo": 23,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                              "inApp": false,
+                              "lineNo": 71,
+                              "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                              "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  66,
+                                  "            }"
+                                ],
+                                [
+                                  67,
+                                  "            // Attempt to invoke user-land function"
+                                ],
+                                [
+                                  68,
+                                  "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                ],
+                                [
+                                  69,
+                                  "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                ],
+                                [
+                                  70,
+                                  "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                ],
+                                [
+                                  71,
+                                  "            return fn.apply(this, wrappedArguments);"
+                                ],
+                                [
+                                  72,
+                                  "            // tslint:enable:no-unsafe-any"
+                                ],
+                                [
+                                  73,
+                                  "        }"
+                                ],
+                                [
+                                  74,
+                                  "        catch (ex) {"
+                                ],
+                                [
+                                  75,
+                                  "            ignoreNextOnError();"
+                                ],
+                                [
+                                  76,
+                                  "            withScope(function (scope) {"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            },
+                            {
+                              "function": "apply",
+                              "errors": null,
+                              "colNo": 24,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                              "inApp": false,
+                              "lineNo": 74,
+                              "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                              "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  69,
+                                  "     */"
+                                ],
+                                [
+                                  70,
+                                  "    triggerAsync: function triggerAsync() {"
+                                ],
+                                [
+                                  71,
+                                  "        var args = arguments,"
+                                ],
+                                [
+                                  72,
+                                  "            me = this;"
+                                ],
+                                [
+                                  73,
+                                  "        _.nextTick(function () {"
+                                ],
+                                [
+                                  74,
+                                  "            me.trigger.apply(me, args);"
+                                ],
+                                [
+                                  75,
+                                  "        });"
+                                ],
+                                [
+                                  76,
+                                  "    },"
+                                ],
+                                [
+                                  77,
+                                  ""
+                                ],
+                                [
+                                  78,
+                                  "    /**"
+                                ],
+                                [
+                                  79,
+                                  "     * Wraps the trigger mechanism with a deferral function."
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            }
+                          ],
+                          "framesOmitted": null,
+                          "registers": null,
+                          "hasSystemFrames": true
+                        },
+                        "module": null,
+                        "rawStacktrace": {
+                          "frames": [
+                            {
+                              "function": "a",
+                              "errors": null,
+                              "colNo": 88800,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "inApp": false,
+                              "lineNo": 81,
+                              "module": null,
+                              "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  76,
+                                  "/*!"
+                                ],
+                                [
+                                  77,
+                                  "  Copyright (c) 2018 Jed Watson."
+                                ],
+                                [
+                                  78,
+                                  "  Licensed under the MIT License (MIT), see"
+                                ],
+                                [
+                                  79,
+                                  "  http://jedwatson.github.io/react-select"
+                                ],
+                                [
+                                  80,
+                                  "*/"
+                                ],
+                                [
+                                  81,
+                                  "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                ],
+                                [
+                                  82,
+                                  "/*!"
+                                ],
+                                [
+                                  83,
+                                  " * JavaScript Cookie v2.2.1"
+                                ],
+                                [
+                                  84,
+                                  " * https://github.com/js-cookie/js-cookie"
+                                ],
+                                [
+                                  85,
+                                  " *"
+                                ],
+                                [
+                                  86,
+                                  " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            },
+                            {
+                              "function": null,
+                              "errors": null,
+                              "colNo": 149484,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "inApp": false,
+                              "lineNo": 119,
+                              "module": null,
+                              "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  114,
+                                  "/* @license"
+                                ],
+                                [
+                                  115,
+                                  "Papa Parse"
+                                ],
+                                [
+                                  116,
+                                  "v5.2.0"
+                                ],
+                                [
+                                  117,
+                                  "https://github.com/mholt/PapaParse"
+                                ],
+                                [
+                                  118,
+                                  "License: MIT"
+                                ],
+                                [
+                                  119,
+                                  "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                ],
+                                [
+                                  120,
+                                  "/**!"
+                                ],
+                                [
+                                  121,
+                                  " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                ],
+                                [
+                                  122,
+                                  " * @version 1.16.1"
+                                ],
+                                [
+                                  123,
+                                  " * @license"
+                                ],
+                                [
+                                  124,
+                                  " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            }
+                          ],
+                          "framesOmitted": null,
+                          "registers": null,
+                          "hasSystemFrames": true
+                        },
+                        "mechanism": {
+                          "type": "generic",
+                          "handled": true
+                        },
+                        "threadId": null,
+                        "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                        "type": "ForbiddenError"
+                      }
+                    ],
+                    "excOmitted": null,
+                    "hasSystemFrames": true
+                  }
+                },
+                {
+                  "type": "breadcrumbs",
+                  "data": {
+                    "values": [
+                      {
+                        "category": "tracing",
+                        "level": "debug",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.266586Z",
+                        "data": null,
+                        "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                        "type": "debug"
+                      },
+                      {
+                        "category": "xhr",
+                        "level": "info",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.619446Z",
+                        "data": {
+                          "url": "/api/0/internal/health/",
+                          "status_code": 200,
+                          "method": "GET"
+                        },
+                        "message": null,
+                        "type": "http"
+                      },
+                      {
+                        "category": "sentry.transaction",
+                        "level": "info",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.945016Z",
+                        "data": null,
+                        "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                        "type": "default"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "request",
+                  "data": {
+                    "fragment": null,
+                    "cookies": [],
+                    "inferredContentType": null,
+                    "env": null,
+                    "headers": [
+                      [
+                        "User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                      ]
+                    ],
+                    "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                    "query": [
+                      [
+                        "project",
+                        "5236886"
+                      ]
+                    ],
+                    "data": null,
+                    "method": null
+                  }
+                }
+              ],
+              "packages": {},
+              "sdk": {
+                "version": "5.17.0",
+                "name": "sentry.javascript.browser"
+              },
+              "_meta": {
+                "user": null,
+                "context": null,
+                "entries": {},
+                "contexts": null,
+                "message": null,
+                "packages": null,
+                "tags": {},
+                "sdk": null
+              },
+              "contexts": {
+                "ForbiddenError": {
+                  "status": 403,
+                  "statusText": "Forbidden",
+                  "responseJSON": {
+                    "detail": "You do not have permission to perform this action."
+                  },
+                  "type": "default"
+                },
+                "browser": {
+                  "version": "83.0.4103",
+                  "type": "browser",
+                  "name": "Chrome"
+                },
+                "os": {
+                  "version": "10",
+                  "type": "os",
+                  "name": "Windows"
+                },
+                "trace": {
+                  "span_id": "83db1ad17e67dfe7",
+                  "type": "trace",
+                  "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                  "op": "navigation"
+                },
+                "organization": {
+                  "type": "default",
+                  "id": "323938",
+                  "slug": "hellboy-meowmeow"
+                }
+              },
+              "fingerprints": [
+                "fbe908cc63d63ea9763fd84cb6bad177"
+              ],
+              "context": {
+                "resp": {
+                  "status": 403,
+                  "responseJSON": {
+                    "detail": "You do not have permission to perform this action."
+                  },
+                  "name": "ForbiddenError",
+                  "statusText": "Forbidden",
+                  "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                  "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                }
+              },
+              "release": {
+                "dateReleased": "2020-06-17T19:21:02.186004Z",
+                "newGroups": 4,
+                "commitCount": 11,
+                "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                "data": {},
+                "lastDeploy": {
+                  "name": "b65bc521378269d3eaefdc964f8ef56621414943 to prod",
+                  "url": null,
+                  "environment": "prod",
+                  "dateStarted": null,
+                  "dateFinished": "2020-06-17T19:20:55.641748Z",
+                  "id": "6883490"
+                },
+                "deployCount": 1,
+                "dateCreated": "2020-06-17T18:45:31.042157Z",
+                "lastEvent": "2020-07-08T21:21:21Z",
+                "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                "firstEvent": "2020-06-17T22:25:14Z",
+                "lastCommit": {
+                  "repository": {
+                    "status": "active",
+                    "integrationId": "2933",
+                    "externalSlug": "getsentry/getsentry",
+                    "name": "getsentry/getsentry",
+                    "provider": {
+                      "id": "integrations:github",
+                      "name": "GitHub"
+                    },
+                    "url": "https://github.com/getsentry/getsentry",
+                    "id": "2",
+                    "dateCreated": "2016-10-10T21:36:45.373994Z"
+                  },
+                  "releases": [
+                    {
+                      "dateReleased": "2020-06-23T13:26:18.427090Z",
+                      "url": "https://freight.getsentry.net/deploys/getsentry/staging/2077/",
+                      "dateCreated": "2020-06-23T13:22:50.420265Z",
+                      "version": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                      "shortVersion": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                      "ref": "perf/source-maps-test"
+                    },
+                    {
+                      "dateReleased": "2020-06-17T19:21:02.186004Z",
+                      "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                      "dateCreated": "2020-06-17T18:45:31.042157Z",
+                      "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                      "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                      "ref": "master"
+                    }
+                  ],
+                  "dateCreated": "2020-06-17T18:43:37Z",
+                  "message": "feat(billing): Get a lot of money",
+                  "id": "b65bc521378269d3eaefdc964f8ef56621414943"
+                },
+                "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                "authors": [
+                  {
+                    "username": "a37a1b4520ce46cea147ae2885a4e7e7",
+                    "lastLogin": "2020-09-14T22:34:55.550640Z",
+                    "isSuperuser": false,
+                    "isManaged": false,
+                    "experiments": {},
+                    "lastActive": "2020-09-15T22:13:20.503880Z",
+                    "isStaff": false,
+                    "id": "655784",
+                    "isActive": true,
+                    "has2fa": false,
+                    "name": "hell.boy@sentry.io",
+                    "avatarUrl": "https://secure.gravatar.com/avatar/eaa22e25b3a984659420831a77e4874e?s=32&d=mm",
+                    "dateJoined": "2020-04-20T16:21:25.365772Z",
+                    "emails": [
+                      {
+                        "is_verified": false,
+                        "id": "784574",
+                        "email": "hellboy@gmail.com"
+                      },
+                      {
+                        "is_verified": true,
+                        "id": "749185",
+                        "email": "hell.boy@sentry.io"
+                      }
+                    ],
+                    "avatar": {
+                      "avatarUuid": null,
+                      "avatarType": "letter_avatar"
+                    },
+                    "hasPasswordAuth": false,
+                    "email": "hell.boy@sentry.io"
+                  }
+                ],
+                "owner": null,
+                "ref": "master",
+                "projects": [
+                  {
+                    "name": "Sentry CSP",
+                    "slug": "sentry-csp"
+                  },
+                  {
+                    "name": "Backend",
+                    "slug": "sentry"
+                  },
+                  {
+                    "name": "Frontend",
+                    "slug": "javascript"
+                  }
+                ]
+              },
+              "groupID": "1341191803"
             }
           }
         }

--- a/paths/events/oldest-event.json
+++ b/paths/events/oldest-event.json
@@ -164,7 +164,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             },
                             {
                               "function": "apply",
@@ -228,7 +227,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             }
                           ],
                           "framesOmitted": null,
@@ -300,7 +298,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             },
                             {
                               "function": null,
@@ -364,7 +361,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             }
                           ],
                           "framesOmitted": null,

--- a/paths/events/oldest-event.json
+++ b/paths/events/oldest-event.json
@@ -22,7 +22,601 @@
         "content": {
           "application/json": {
             "schema": {
-                "$ref": "../../components/schemas/event.json#/EventDetailed"
+              "$ref": "../../components/schemas/event.json#/EventDetailed"
+            },
+            "example": {
+              "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+              "dist": null,
+              "userReport": null,
+              "previousEventID": null,
+              "message": "",
+              "id": "9999aaafcc8b46d797c23c6077c6ff01",
+              "size": 107762,
+              "errors": [
+                {
+                  "data": {
+                    "column": 8,
+                    "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                    "row": 15
+                  },
+                  "message": "Invalid location in sourcemap",
+                  "type": "js_invalid_sourcemap_location"
+                }
+              ],
+              "platform": "javascript",
+              "nextEventID": "99f9e199e9a74a14bfef6196ad741619",
+              "type": "error",
+              "metadata": {
+                "type": "ForbiddenError",
+                "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+              },
+              "tags": [
+                {
+                  "value": "Chrome 83.0.4103",
+                  "key": "browser",
+                  "_meta": null
+                },
+                {
+                  "value": "Chrome",
+                  "key": "browser.name",
+                  "_meta": null
+                },
+                {
+                  "value": "prod",
+                  "key": "environment",
+                  "_meta": null
+                },
+                {
+                  "value": "yes",
+                  "key": "handled",
+                  "_meta": null
+                },
+                {
+                  "value": "error",
+                  "key": "level",
+                  "_meta": null
+                },
+                {
+                  "value": "generic",
+                  "key": "mechanism",
+                  "_meta": null
+                }
+              ],
+              "dateCreated": "2020-06-17T22:26:56.098086Z",
+              "dateReceived": "2020-06-17T22:26:56.428721Z",
+              "user": {
+                "username": null,
+                "name": "Hell Boy",
+                "ip_address": "192.168.1.1",
+                "email": "hell@boy.cat",
+                "data": {
+                  "isStaff": false
+                },
+                "id": "550747"
+              },
+              "entries": [
+                {
+                  "type": "exception",
+                  "data": {
+                    "values": [
+                      {
+                        "stacktrace": {
+                          "frames": [
+                            {
+                              "function": "ignoreOnError",
+                              "errors": null,
+                              "colNo": 23,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                              "inApp": false,
+                              "lineNo": 71,
+                              "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                              "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  66,
+                                  "            }"
+                                ],
+                                [
+                                  67,
+                                  "            // Attempt to invoke user-land function"
+                                ],
+                                [
+                                  68,
+                                  "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                ],
+                                [
+                                  69,
+                                  "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                ],
+                                [
+                                  70,
+                                  "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                ],
+                                [
+                                  71,
+                                  "            return fn.apply(this, wrappedArguments);"
+                                ],
+                                [
+                                  72,
+                                  "            // tslint:enable:no-unsafe-any"
+                                ],
+                                [
+                                  73,
+                                  "        }"
+                                ],
+                                [
+                                  74,
+                                  "        catch (ex) {"
+                                ],
+                                [
+                                  75,
+                                  "            ignoreNextOnError();"
+                                ],
+                                [
+                                  76,
+                                  "            withScope(function (scope) {"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            },
+                            {
+                              "function": "apply",
+                              "errors": null,
+                              "colNo": 24,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                              "inApp": false,
+                              "lineNo": 74,
+                              "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                              "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  69,
+                                  "     */"
+                                ],
+                                [
+                                  70,
+                                  "    triggerAsync: function triggerAsync() {"
+                                ],
+                                [
+                                  71,
+                                  "        var args = arguments,"
+                                ],
+                                [
+                                  72,
+                                  "            me = this;"
+                                ],
+                                [
+                                  73,
+                                  "        _.nextTick(function () {"
+                                ],
+                                [
+                                  74,
+                                  "            me.trigger.apply(me, args);"
+                                ],
+                                [
+                                  75,
+                                  "        });"
+                                ],
+                                [
+                                  76,
+                                  "    },"
+                                ],
+                                [
+                                  77,
+                                  ""
+                                ],
+                                [
+                                  78,
+                                  "    /**"
+                                ],
+                                [
+                                  79,
+                                  "     * Wraps the trigger mechanism with a deferral function."
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            }
+                          ],
+                          "framesOmitted": null,
+                          "registers": null,
+                          "hasSystemFrames": true
+                        },
+                        "module": null,
+                        "rawStacktrace": {
+                          "frames": [
+                            {
+                              "function": "a",
+                              "errors": null,
+                              "colNo": 88800,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "inApp": false,
+                              "lineNo": 81,
+                              "module": null,
+                              "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  76,
+                                  "/*!"
+                                ],
+                                [
+                                  77,
+                                  "  Copyright (c) 2018 Jed Watson."
+                                ],
+                                [
+                                  78,
+                                  "  Licensed under the MIT License (MIT), see"
+                                ],
+                                [
+                                  79,
+                                  "  http://jedwatson.github.io/react-select"
+                                ],
+                                [
+                                  80,
+                                  "*/"
+                                ],
+                                [
+                                  81,
+                                  "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                ],
+                                [
+                                  82,
+                                  "/*!"
+                                ],
+                                [
+                                  83,
+                                  " * JavaScript Cookie v2.2.1"
+                                ],
+                                [
+                                  84,
+                                  " * https://github.com/js-cookie/js-cookie"
+                                ],
+                                [
+                                  85,
+                                  " *"
+                                ],
+                                [
+                                  86,
+                                  " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            },
+                            {
+                              "function": null,
+                              "errors": null,
+                              "colNo": 149484,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "inApp": false,
+                              "lineNo": 119,
+                              "module": null,
+                              "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  114,
+                                  "/* @license"
+                                ],
+                                [
+                                  115,
+                                  "Papa Parse"
+                                ],
+                                [
+                                  116,
+                                  "v5.2.0"
+                                ],
+                                [
+                                  117,
+                                  "https://github.com/mholt/PapaParse"
+                                ],
+                                [
+                                  118,
+                                  "License: MIT"
+                                ],
+                                [
+                                  119,
+                                  "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                ],
+                                [
+                                  120,
+                                  "/**!"
+                                ],
+                                [
+                                  121,
+                                  " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                ],
+                                [
+                                  122,
+                                  " * @version 1.16.1"
+                                ],
+                                [
+                                  123,
+                                  " * @license"
+                                ],
+                                [
+                                  124,
+                                  " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            }
+                          ],
+                          "framesOmitted": null,
+                          "registers": null,
+                          "hasSystemFrames": true
+                        },
+                        "mechanism": {
+                          "type": "generic",
+                          "handled": true
+                        },
+                        "threadId": null,
+                        "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                        "type": "ForbiddenError"
+                      }
+                    ],
+                    "excOmitted": null,
+                    "hasSystemFrames": true
+                  }
+                },
+                {
+                  "type": "breadcrumbs",
+                  "data": {
+                    "values": [
+                      {
+                        "category": "tracing",
+                        "level": "debug",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.266586Z",
+                        "data": null,
+                        "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                        "type": "debug"
+                      },
+                      {
+                        "category": "xhr",
+                        "level": "info",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.619446Z",
+                        "data": {
+                          "url": "/api/0/internal/health/",
+                          "status_code": 200,
+                          "method": "GET"
+                        },
+                        "message": null,
+                        "type": "http"
+                      },
+                      {
+                        "category": "sentry.transaction",
+                        "level": "info",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.945016Z",
+                        "data": null,
+                        "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                        "type": "default"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "request",
+                  "data": {
+                    "fragment": null,
+                    "cookies": [],
+                    "inferredContentType": null,
+                    "env": null,
+                    "headers": [
+                      [
+                        "User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                      ]
+                    ],
+                    "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                    "query": [
+                      [
+                        "project",
+                        "5236886"
+                      ]
+                    ],
+                    "data": null,
+                    "method": null
+                  }
+                }
+              ],
+              "packages": {},
+              "sdk": {
+                "version": "5.17.0",
+                "name": "sentry.javascript.browser"
+              },
+              "_meta": {
+                "user": null,
+                "context": null,
+                "entries": {},
+                "contexts": null,
+                "message": null,
+                "packages": null,
+                "tags": {},
+                "sdk": null
+              },
+              "contexts": {
+                "ForbiddenError": {
+                  "status": 403,
+                  "statusText": "Forbidden",
+                  "responseJSON": {
+                    "detail": "You do not have permission to perform this action."
+                  },
+                  "type": "default"
+                },
+                "browser": {
+                  "version": "83.0.4103",
+                  "type": "browser",
+                  "name": "Chrome"
+                },
+                "os": {
+                  "version": "10",
+                  "type": "os",
+                  "name": "Windows"
+                },
+                "trace": {
+                  "span_id": "83db1ad17e67dfe7",
+                  "type": "trace",
+                  "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                  "op": "navigation"
+                },
+                "organization": {
+                  "type": "default",
+                  "id": "323938",
+                  "slug": "hellboy-meowmeow"
+                }
+              },
+              "fingerprints": [
+                "fbe908cc63d63ea9763fd84cb6bad177"
+              ],
+              "context": {
+                "resp": {
+                  "status": 403,
+                  "responseJSON": {
+                    "detail": "You do not have permission to perform this action."
+                  },
+                  "name": "ForbiddenError",
+                  "statusText": "Forbidden",
+                  "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                  "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                }
+              },
+              "release": {
+                "dateReleased": "2020-06-17T19:21:02.186004Z",
+                "newGroups": 4,
+                "commitCount": 11,
+                "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                "data": {},
+                "lastDeploy": {
+                  "name": "b65bc521378269d3eaefdc964f8ef56621414943 to prod",
+                  "url": null,
+                  "environment": "prod",
+                  "dateStarted": null,
+                  "dateFinished": "2020-06-17T19:20:55.641748Z",
+                  "id": "6883490"
+                },
+                "deployCount": 1,
+                "dateCreated": "2020-06-17T18:45:31.042157Z",
+                "lastEvent": "2020-07-08T21:21:21Z",
+                "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                "firstEvent": "2020-06-17T22:25:14Z",
+                "lastCommit": {
+                  "repository": {
+                    "status": "active",
+                    "integrationId": "2933",
+                    "externalSlug": "getsentry/getsentry",
+                    "name": "getsentry/getsentry",
+                    "provider": {
+                      "id": "integrations:github",
+                      "name": "GitHub"
+                    },
+                    "url": "https://github.com/getsentry/getsentry",
+                    "id": "2",
+                    "dateCreated": "2016-10-10T21:36:45.373994Z"
+                  },
+                  "releases": [
+                    {
+                      "dateReleased": "2020-06-23T13:26:18.427090Z",
+                      "url": "https://freight.getsentry.net/deploys/getsentry/staging/2077/",
+                      "dateCreated": "2020-06-23T13:22:50.420265Z",
+                      "version": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                      "shortVersion": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                      "ref": "perf/source-maps-test"
+                    },
+                    {
+                      "dateReleased": "2020-06-17T19:21:02.186004Z",
+                      "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                      "dateCreated": "2020-06-17T18:45:31.042157Z",
+                      "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                      "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                      "ref": "master"
+                    }
+                  ],
+                  "dateCreated": "2020-06-17T18:43:37Z",
+                  "message": "feat(billing): Get a lot of money",
+                  "id": "b65bc521378269d3eaefdc964f8ef56621414943"
+                },
+                "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                "authors": [
+                  {
+                    "username": "a37a1b4520ce46cea147ae2885a4e7e7",
+                    "lastLogin": "2020-09-14T22:34:55.550640Z",
+                    "isSuperuser": false,
+                    "isManaged": false,
+                    "experiments": {},
+                    "lastActive": "2020-09-15T22:13:20.503880Z",
+                    "isStaff": false,
+                    "id": "655784",
+                    "isActive": true,
+                    "has2fa": false,
+                    "name": "hell.boy@sentry.io",
+                    "avatarUrl": "https://secure.gravatar.com/avatar/eaa22e25b3a984659420831a77e4874e?s=32&d=mm",
+                    "dateJoined": "2020-04-20T16:21:25.365772Z",
+                    "emails": [
+                      {
+                        "is_verified": false,
+                        "id": "784574",
+                        "email": "hellboy@gmail.com"
+                      },
+                      {
+                        "is_verified": true,
+                        "id": "749185",
+                        "email": "hell.boy@sentry.io"
+                      }
+                    ],
+                    "avatar": {
+                      "avatarUuid": null,
+                      "avatarType": "letter_avatar"
+                    },
+                    "hasPasswordAuth": false,
+                    "email": "hell.boy@sentry.io"
+                  }
+                ],
+                "owner": null,
+                "ref": "master",
+                "projects": [
+                  {
+                    "name": "Sentry CSP",
+                    "slug": "sentry-csp"
+                  },
+                  {
+                    "name": "Backend",
+                    "slug": "sentry"
+                  },
+                  {
+                    "name": "Frontend",
+                    "slug": "javascript"
+                  }
+                ]
+              },
+              "groupID": "1341191803"
             }
           }
         }

--- a/paths/events/project-event-details.json
+++ b/paths/events/project-event-details.json
@@ -41,6 +41,600 @@
           "application/json": {
             "schema": {
               "$ref": "../../components/schemas/event.json#/EventDetailed"
+            },
+            "example": {
+              "eventID": "9999aaaaca8b46d797c23c6077c6ff01",
+              "dist": null,
+              "userReport": null,
+              "previousEventID": null,
+              "message": "",
+              "id": "9999aaafcc8b46d797c23c6077c6ff01",
+              "size": 107762,
+              "errors": [
+                {
+                  "data": {
+                    "column": 8,
+                    "source": "https://s1.sentry-cdn.com/_static/bloopbloop/sentry/dist/app.js.map",
+                    "row": 15
+                  },
+                  "message": "Invalid location in sourcemap",
+                  "type": "js_invalid_sourcemap_location"
+                }
+              ],
+              "platform": "javascript",
+              "nextEventID": "99f9e199e9a74a14bfef6196ad741619",
+              "type": "error",
+              "metadata": {
+                "type": "ForbiddenError",
+                "value": "GET /organizations/hellboy-meowmeow/users/ 403"
+              },
+              "tags": [
+                {
+                  "value": "Chrome 83.0.4103",
+                  "key": "browser",
+                  "_meta": null
+                },
+                {
+                  "value": "Chrome",
+                  "key": "browser.name",
+                  "_meta": null
+                },
+                {
+                  "value": "prod",
+                  "key": "environment",
+                  "_meta": null
+                },
+                {
+                  "value": "yes",
+                  "key": "handled",
+                  "_meta": null
+                },
+                {
+                  "value": "error",
+                  "key": "level",
+                  "_meta": null
+                },
+                {
+                  "value": "generic",
+                  "key": "mechanism",
+                  "_meta": null
+                }
+              ],
+              "dateCreated": "2020-06-17T22:26:56.098086Z",
+              "dateReceived": "2020-06-17T22:26:56.428721Z",
+              "user": {
+                "username": null,
+                "name": "Hell Boy",
+                "ip_address": "192.168.1.1",
+                "email": "hell@boy.cat",
+                "data": {
+                  "isStaff": false
+                },
+                "id": "550747"
+              },
+              "entries": [
+                {
+                  "type": "exception",
+                  "data": {
+                    "values": [
+                      {
+                        "stacktrace": {
+                          "frames": [
+                            {
+                              "function": "ignoreOnError",
+                              "errors": null,
+                              "colNo": 23,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                              "inApp": false,
+                              "lineNo": 71,
+                              "module": "usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers",
+                              "filename": "/usr/src/getsentry/src/sentry/node_modules/@sentry/browser/esm/helpers.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  66,
+                                  "            }"
+                                ],
+                                [
+                                  67,
+                                  "            // Attempt to invoke user-land function"
+                                ],
+                                [
+                                  68,
+                                  "            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it"
+                                ],
+                                [
+                                  69,
+                                  "            //       means the sentry.javascript SDK caught an error invoking your application code. This"
+                                ],
+                                [
+                                  70,
+                                  "            //       is expected behavior and NOT indicative of a bug with sentry.javascript."
+                                ],
+                                [
+                                  71,
+                                  "            return fn.apply(this, wrappedArguments);"
+                                ],
+                                [
+                                  72,
+                                  "            // tslint:enable:no-unsafe-any"
+                                ],
+                                [
+                                  73,
+                                  "        }"
+                                ],
+                                [
+                                  74,
+                                  "        catch (ex) {"
+                                ],
+                                [
+                                  75,
+                                  "            ignoreNextOnError();"
+                                ],
+                                [
+                                  76,
+                                  "            withScope(function (scope) {"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            },
+                            {
+                              "function": "apply",
+                              "errors": null,
+                              "colNo": 24,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "webpack:////usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                              "inApp": false,
+                              "lineNo": 74,
+                              "module": "usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods",
+                              "filename": "/usr/src/getsentry/src/sentry/node_modules/reflux-core/lib/PublisherMethods.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  69,
+                                  "     */"
+                                ],
+                                [
+                                  70,
+                                  "    triggerAsync: function triggerAsync() {"
+                                ],
+                                [
+                                  71,
+                                  "        var args = arguments,"
+                                ],
+                                [
+                                  72,
+                                  "            me = this;"
+                                ],
+                                [
+                                  73,
+                                  "        _.nextTick(function () {"
+                                ],
+                                [
+                                  74,
+                                  "            me.trigger.apply(me, args);"
+                                ],
+                                [
+                                  75,
+                                  "        });"
+                                ],
+                                [
+                                  76,
+                                  "    },"
+                                ],
+                                [
+                                  77,
+                                  ""
+                                ],
+                                [
+                                  78,
+                                  "    /**"
+                                ],
+                                [
+                                  79,
+                                  "     * Wraps the trigger mechanism with a deferral function."
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            }
+                          ],
+                          "framesOmitted": null,
+                          "registers": null,
+                          "hasSystemFrames": true
+                        },
+                        "module": null,
+                        "rawStacktrace": {
+                          "frames": [
+                            {
+                              "function": "a",
+                              "errors": null,
+                              "colNo": 88800,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "inApp": false,
+                              "lineNo": 81,
+                              "module": null,
+                              "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  76,
+                                  "/*!"
+                                ],
+                                [
+                                  77,
+                                  "  Copyright (c) 2018 Jed Watson."
+                                ],
+                                [
+                                  78,
+                                  "  Licensed under the MIT License (MIT), see"
+                                ],
+                                [
+                                  79,
+                                  "  http://jedwatson.github.io/react-select"
+                                ],
+                                [
+                                  80,
+                                  "*/"
+                                ],
+                                [
+                                  81,
+                                  "{snip} e,t)}));return e.handleEvent?e.handleEvent.apply(this,s):e.apply(this,s)}catch(e){throw c(),Object(o.m)((function(n){n.addEventProcessor((fu {snip}"
+                                ],
+                                [
+                                  82,
+                                  "/*!"
+                                ],
+                                [
+                                  83,
+                                  " * JavaScript Cookie v2.2.1"
+                                ],
+                                [
+                                  84,
+                                  " * https://github.com/js-cookie/js-cookie"
+                                ],
+                                [
+                                  85,
+                                  " *"
+                                ],
+                                [
+                                  86,
+                                  " * Copyright 2006, 2015 Klaus Hartl & Fagner Brack"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            },
+                            {
+                              "function": null,
+                              "errors": null,
+                              "colNo": 149484,
+                              "vars": null,
+                              "package": null,
+                              "absPath": "https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "inApp": false,
+                              "lineNo": 119,
+                              "module": null,
+                              "filename": "/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js",
+                              "platform": null,
+                              "instructionAddr": null,
+                              "context": [
+                                [
+                                  114,
+                                  "/* @license"
+                                ],
+                                [
+                                  115,
+                                  "Papa Parse"
+                                ],
+                                [
+                                  116,
+                                  "v5.2.0"
+                                ],
+                                [
+                                  117,
+                                  "https://github.com/mholt/PapaParse"
+                                ],
+                                [
+                                  118,
+                                  "License: MIT"
+                                ],
+                                [
+                                  119,
+                                  "{snip} (){var e=arguments,t=this;r.nextTick((function(){t.trigger.apply(t,e)}))},deferWith:function(e){var t=this.trigger,n=this,r=function(){t.app {snip}"
+                                ],
+                                [
+                                  120,
+                                  "/**!"
+                                ],
+                                [
+                                  121,
+                                  " * @fileOverview Kickass library to create and place poppers near their reference elements."
+                                ],
+                                [
+                                  122,
+                                  " * @version 1.16.1"
+                                ],
+                                [
+                                  123,
+                                  " * @license"
+                                ],
+                                [
+                                  124,
+                                  " * Copyright (c) 2016 Federico Zivolo and contributors"
+                                ]
+                              ],
+                              "symbolAddr": null,
+                              "trust": null,
+                              "symbol": null,
+                              "rawFunction": null
+                            }
+                          ],
+                          "framesOmitted": null,
+                          "registers": null,
+                          "hasSystemFrames": true
+                        },
+                        "mechanism": {
+                          "type": "generic",
+                          "handled": true
+                        },
+                        "threadId": null,
+                        "value": "GET /organizations/hellboy-meowmeow/users/ 403",
+                        "type": "ForbiddenError"
+                      }
+                    ],
+                    "excOmitted": null,
+                    "hasSystemFrames": true
+                  }
+                },
+                {
+                  "type": "breadcrumbs",
+                  "data": {
+                    "values": [
+                      {
+                        "category": "tracing",
+                        "level": "debug",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.266586Z",
+                        "data": null,
+                        "message": "[Tracing] pushActivity: idleTransactionStarted#1",
+                        "type": "debug"
+                      },
+                      {
+                        "category": "xhr",
+                        "level": "info",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.619446Z",
+                        "data": {
+                          "url": "/api/0/internal/health/",
+                          "status_code": 200,
+                          "method": "GET"
+                        },
+                        "message": null,
+                        "type": "http"
+                      },
+                      {
+                        "category": "sentry.transaction",
+                        "level": "info",
+                        "event_id": null,
+                        "timestamp": "2020-06-17T22:26:55.945016Z",
+                        "data": null,
+                        "message": "7787a027f3fb46c985aaa2287b3f4d09",
+                        "type": "default"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "request",
+                  "data": {
+                    "fragment": null,
+                    "cookies": [],
+                    "inferredContentType": null,
+                    "env": null,
+                    "headers": [
+                      [
+                        "User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
+                      ]
+                    ],
+                    "url": "https://sentry.io/organizations/hellboy-meowmeow/issues/",
+                    "query": [
+                      [
+                        "project",
+                        "5236886"
+                      ]
+                    ],
+                    "data": null,
+                    "method": null
+                  }
+                }
+              ],
+              "packages": {},
+              "sdk": {
+                "version": "5.17.0",
+                "name": "sentry.javascript.browser"
+              },
+              "_meta": {
+                "user": null,
+                "context": null,
+                "entries": {},
+                "contexts": null,
+                "message": null,
+                "packages": null,
+                "tags": {},
+                "sdk": null
+              },
+              "contexts": {
+                "ForbiddenError": {
+                  "status": 403,
+                  "statusText": "Forbidden",
+                  "responseJSON": {
+                    "detail": "You do not have permission to perform this action."
+                  },
+                  "type": "default"
+                },
+                "browser": {
+                  "version": "83.0.4103",
+                  "type": "browser",
+                  "name": "Chrome"
+                },
+                "os": {
+                  "version": "10",
+                  "type": "os",
+                  "name": "Windows"
+                },
+                "trace": {
+                  "span_id": "83db1ad17e67dfe7",
+                  "type": "trace",
+                  "trace_id": "da6caabcd90e45fdb81f6655824a5f88",
+                  "op": "navigation"
+                },
+                "organization": {
+                  "type": "default",
+                  "id": "323938",
+                  "slug": "hellboy-meowmeow"
+                }
+              },
+              "fingerprints": [
+                "fbe908cc63d63ea9763fd84cb6bad177"
+              ],
+              "context": {
+                "resp": {
+                  "status": 403,
+                  "responseJSON": {
+                    "detail": "You do not have permission to perform this action."
+                  },
+                  "name": "ForbiddenError",
+                  "statusText": "Forbidden",
+                  "message": "GET /organizations/hellboy-meowmeow/users/ 403",
+                  "stack": "Error\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480441\n    at u (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51006)\n    at Generator._invoke (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:50794)\n    at Generator.A.forEach.e.<computed> [as next] (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:165:51429)\n    at n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68684)\n    at s (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68895)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68954\n    at new Promise (<anonymous>)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:16:68835\n    at v (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480924)\n    at m (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:480152)\n    at t.fetchMemberList (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:902983)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:900527)\n    at t.componentDidMount (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:15597)\n    at Pc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:101023)\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Rc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:97371)\n    at Oc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:87690)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45820\n    at t.unstable_runWithPriority (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:3462)\n    at Ko (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45529)\n    at Zo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45765)\n    at Jo (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:45700)\n    at gc (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:84256)\n    at Object.enqueueSetState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:181:50481)\n    at t.M.setState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:173:1439)\n    at t.onUpdate (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:543076)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at p.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at p.onInitializeUrlState (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/app.js:1:541711)\n    at a.n (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149090)\n    at a.emit (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:189:6550)\n    at Function.trigger (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149379)\n    at https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:119:149484\n    at a (https://s1.sentry-cdn.com/_static/dde778f9f93a48e2b6e58ecb0c5eb8f2/sentry/dist/vendor.js:81:88800)"
+                }
+              },
+              "release": {
+                "dateReleased": "2020-06-17T19:21:02.186004Z",
+                "newGroups": 4,
+                "commitCount": 11,
+                "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                "data": {},
+                "lastDeploy": {
+                  "name": "b65bc521378269d3eaefdc964f8ef56621414943 to prod",
+                  "url": null,
+                  "environment": "prod",
+                  "dateStarted": null,
+                  "dateFinished": "2020-06-17T19:20:55.641748Z",
+                  "id": "6883490"
+                },
+                "deployCount": 1,
+                "dateCreated": "2020-06-17T18:45:31.042157Z",
+                "lastEvent": "2020-07-08T21:21:21Z",
+                "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                "firstEvent": "2020-06-17T22:25:14Z",
+                "lastCommit": {
+                  "repository": {
+                    "status": "active",
+                    "integrationId": "2933",
+                    "externalSlug": "getsentry/getsentry",
+                    "name": "getsentry/getsentry",
+                    "provider": {
+                      "id": "integrations:github",
+                      "name": "GitHub"
+                    },
+                    "url": "https://github.com/getsentry/getsentry",
+                    "id": "2",
+                    "dateCreated": "2016-10-10T21:36:45.373994Z"
+                  },
+                  "releases": [
+                    {
+                      "dateReleased": "2020-06-23T13:26:18.427090Z",
+                      "url": "https://freight.getsentry.net/deploys/getsentry/staging/2077/",
+                      "dateCreated": "2020-06-23T13:22:50.420265Z",
+                      "version": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                      "shortVersion": "f3783e5fe710758724f14267439fd46cc2bf5918",
+                      "ref": "perf/source-maps-test"
+                    },
+                    {
+                      "dateReleased": "2020-06-17T19:21:02.186004Z",
+                      "url": "https://freight.getsentry.net/deploys/getsentry/production/8868/",
+                      "dateCreated": "2020-06-17T18:45:31.042157Z",
+                      "version": "b65bc521378269d3eaefdc964f8ef56621414943",
+                      "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                      "ref": "master"
+                    }
+                  ],
+                  "dateCreated": "2020-06-17T18:43:37Z",
+                  "message": "feat(billing): Get a lot of money",
+                  "id": "b65bc521378269d3eaefdc964f8ef56621414943"
+                },
+                "shortVersion": "b65bc521378269d3eaefdc964f8ef56621414943",
+                "authors": [
+                  {
+                    "username": "a37a1b4520ce46cea147ae2885a4e7e7",
+                    "lastLogin": "2020-09-14T22:34:55.550640Z",
+                    "isSuperuser": false,
+                    "isManaged": false,
+                    "experiments": {},
+                    "lastActive": "2020-09-15T22:13:20.503880Z",
+                    "isStaff": false,
+                    "id": "655784",
+                    "isActive": true,
+                    "has2fa": false,
+                    "name": "hell.boy@sentry.io",
+                    "avatarUrl": "https://secure.gravatar.com/avatar/eaa22e25b3a984659420831a77e4874e?s=32&d=mm",
+                    "dateJoined": "2020-04-20T16:21:25.365772Z",
+                    "emails": [
+                      {
+                        "is_verified": false,
+                        "id": "784574",
+                        "email": "hellboy@gmail.com"
+                      },
+                      {
+                        "is_verified": true,
+                        "id": "749185",
+                        "email": "hell.boy@sentry.io"
+                      }
+                    ],
+                    "avatar": {
+                      "avatarUuid": null,
+                      "avatarType": "letter_avatar"
+                    },
+                    "hasPasswordAuth": false,
+                    "email": "hell.boy@sentry.io"
+                  }
+                ],
+                "owner": null,
+                "ref": "master",
+                "projects": [
+                  {
+                    "name": "Sentry CSP",
+                    "slug": "sentry-csp"
+                  },
+                  {
+                    "name": "Backend",
+                    "slug": "sentry"
+                  },
+                  {
+                    "name": "Frontend",
+                    "slug": "javascript"
+                  }
+                ]
+              },
+              "groupID": "1341191803"
             }
           }
         }

--- a/paths/events/project-event-details.json
+++ b/paths/events/project-event-details.json
@@ -182,7 +182,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             },
                             {
                               "function": "apply",
@@ -246,7 +245,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             }
                           ],
                           "framesOmitted": null,
@@ -318,7 +316,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             },
                             {
                               "function": null,
@@ -382,7 +379,6 @@
                               "symbolAddr": null,
                               "trust": null,
                               "symbol": null,
-                              "rawFunction": null
                             }
                           ],
                           "framesOmitted": null,

--- a/paths/events/project-events.json
+++ b/paths/events/project-events.json
@@ -43,7 +43,53 @@
               "items": {
                 "$ref": "../../components/schemas/event.json#/Event"
               }
-            }
+            },
+            "example": [
+              {
+                "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",
+                "tags": [
+                  {
+                    "key": "browser",
+                    "value": "Chrome 60.0"
+                  },
+                  {
+                    "key": "device",
+                    "value": "Other"
+                  },
+                  {
+                    "key": "environment",
+                    "value": "production"
+                  },
+                  {
+                    "value": "fatal",
+                    "key": "level"
+                  },
+                  {
+                    "key": "os",
+                    "value": "Mac OS X 10.12.6"
+                  },
+                  {
+                    "value": "CPython 2.7.16",
+                    "key": "runtime"
+                  },
+                  {
+                    "key": "release",
+                    "value": "17642328ead24b51867165985996d04b29310337"
+                  },
+                  {
+                    "key": "server_name",
+                    "value": "web1.example.com"
+                  }
+                ],
+                "dateCreated": "2020-09-11T17:46:36Z",
+                "user": null,
+                "message": "This is an example Python exception",
+                "id": "dfb1a2d057194e76a4186cc8a5271553",
+                "platform": "python",
+                "event.type": "error",
+                "groupID": "1889724436"
+              }
+            ]
           }
         }
       },

--- a/paths/organizations/event-id-lookup.json
+++ b/paths/organizations/event-id-lookup.json
@@ -92,44 +92,23 @@
                 "dist": null,
                 "entries": [
                   {
+                    "type": "request",
                     "data": {
-                      "cookies": [
-                        [
-                          "foo",
-                          "bar"
-                        ],
-                        [
-                          "biz",
-                          "baz"
-                        ]
-                      ],
-                      "data": {
-                        "hello": "world"
-                      },
-                      "env": {
-                        "ENV": "prod"
-                      },
-                      "fragment": "",
+                      "fragment": null,
+                      "cookies": [],
+                      "inferredContentType": null,
+                      "env": null,
                       "headers": [
                         [
-                          "Content-Type",
-                          "application/json"
-                        ],
-                        [
-                          "Referer",
-                          "http://example.com"
-                        ],
-                        [
                           "User-Agent",
-                          "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.72 Safari/537.36"
+                          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
                         ]
                       ],
-                      "inferredContentType": "application/json",
-                      "method": "GET",
-                      "query": "foo=bar",
-                      "url": "http://example.com/foo"
-                    },
-                    "type": "request"
+                      "url": "http://example.com/foo",
+                      "query": [],
+                      "data": null,
+                      "method": null
+                    }
                   }
                 ],
                 "errors": [],
@@ -188,6 +167,35 @@
                 ],
                 "type": "default",
                 "user": {
+                  "data": {},
+                  "email": "sentry@example.com",
+                  "id": "1",
+                  "ip_address": "127.0.0.1",
+                  "name": "Sentry",
+                  "username": "sentry"
+                }
+              },
+              "eventId": "1",
+              "groupId": "1",
+              "organizationSlug": "the-interstellar-jurisdiction",
+              "projectSlug": "pump-station"
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "Forbidden"
+      }
+    },
+    "security": [
+      {
+        "auth_token": [
+          "org: read"
+        ]
+      }
+    ]
+  }
+}        "user": {
                   "data": {},
                   "email": "sentry@example.com",
                   "id": "1",

--- a/paths/organizations/event-id-lookup.json
+++ b/paths/organizations/event-id-lookup.json
@@ -1,6 +1,8 @@
 {
   "get": {
-    "tags": ["Organizations"],
+    "tags": [
+      "Organizations"
+    ],
     "description": "This resolves an event ID to the project slug and internal issue ID and internal event ID.",
     "operationId": "Resolve an Event ID",
     "parameters": [
@@ -39,7 +41,7 @@
               ],
               "properties": {
                 "event": {
-                  "type": "object"
+                  "$ref": "../../components/schemas/event.json#/OrganizationEvent"
                 },
                 "eventId": {
                   "type": "string"
@@ -56,11 +58,148 @@
               }
             },
             "example": {
+              "event": {
+                "_meta": {
+                  "context": null,
+                  "contexts": null,
+                  "entries": {},
+                  "message": null,
+                  "packages": null,
+                  "sdk": null,
+                  "tags": {},
+                  "user": null
+                },
+                "context": {
+                  "emptyList": [],
+                  "emptyMap": {},
+                  "length": 10837790,
+                  "results": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "session": {
+                    "foo": "bar"
+                  },
+                  "unauthorized": false,
+                  "url": "http://example.org/foo/bar/"
+                },
+                "contexts": {},
+                "dateCreated": "2018-11-06T21:19:55Z",
+                "dateReceived": "2018-11-06T21:19:55Z",
+                "dist": null,
+                "entries": [
+                  {
+                    "data": {
+                      "cookies": [
+                        [
+                          "foo",
+                          "bar"
+                        ],
+                        [
+                          "biz",
+                          "baz"
+                        ]
+                      ],
+                      "data": {
+                        "hello": "world"
+                      },
+                      "env": {
+                        "ENV": "prod"
+                      },
+                      "fragment": "",
+                      "headers": [
+                        [
+                          "Content-Type",
+                          "application/json"
+                        ],
+                        [
+                          "Referer",
+                          "http://example.com"
+                        ],
+                        [
+                          "User-Agent",
+                          "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.72 Safari/537.36"
+                        ]
+                      ],
+                      "inferredContentType": "application/json",
+                      "method": "GET",
+                      "query": "foo=bar",
+                      "url": "http://example.com/foo"
+                    },
+                    "type": "request"
+                  }
+                ],
+                "errors": [],
+                "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",
+                "fingerprints": [
+                  "c4a4d06bc314205bb3b6bdb612dde7f1"
+                ],
+                "groupID": "1",
+                "id": "1",
+                "message": "This is an example Python exception",
+                "metadata": {
+                  "title": "This is an example Python exception"
+                },
+                "packages": {
+                  "my.package": "1.0.0"
+                },
+                "platform": "python",
+                "sdk": null,
+                "size": 7055,
+                "tags": [
+                  {
+                    "_meta": null,
+                    "key": "browser",
+                    "value": "Chrome 28.0"
+                  },
+                  {
+                    "_meta": null,
+                    "key": "device",
+                    "value": "Other"
+                  },
+                  {
+                    "_meta": null,
+                    "key": "level",
+                    "value": "error"
+                  },
+                  {
+                    "_meta": null,
+                    "key": "os",
+                    "value": "Windows 8"
+                  },
+                  {
+                    "_meta": null,
+                    "key": "release",
+                    "value": "17642328ead24b51867165985996d04b29310337"
+                  },
+                  {
+                    "_meta": null,
+                    "key": "url",
+                    "value": "http://example.com/foo"
+                  },
+                  {
+                    "_meta": null,
+                    "key": "user",
+                    "value": "id:1"
+                  }
+                ],
+                "type": "default",
+                "user": {
+                  "data": {},
+                  "email": "sentry@example.com",
+                  "id": "1",
+                  "ip_address": "127.0.0.1",
+                  "name": "Sentry",
+                  "username": "sentry"
+                }
+              },
               "eventId": "1",
               "groupId": "1",
               "organizationSlug": "the-interstellar-jurisdiction",
-              "projectSlug": "pump-station",
-              "event": {}
+              "projectSlug": "pump-station"
             }
           }
         }
@@ -71,7 +210,9 @@
     },
     "security": [
       {
-        "auth_token": ["org: read"]
+        "auth_token": [
+          "org: read"
+        ]
       }
     ]
   }


### PR DESCRIPTION
This PR adds examples in for the endpoints that return events. 

The event returned in `event-id-lookup.json` is somewhere between `Event` and `EventDetailed` so I'll need to define a new schema for it which I'm calling `OrganizationEvent`.