### PR TITLE
feat(api-docs): Fix tag details example

### DIFF
--- a/openapi-derefed.json
+++ b/openapi-derefed.json
@@ -10000,12 +10000,10 @@
                     }
                   }
                 },
-                "example": [
-                  {
-                    "key": "ice_cream",
-                    "totalValues": 6
-                  }
-                ]
+                "example": {
+                  "key": "ice_cream",
+                  "totalValues": 6
+                }
               }
             }
           },

--- a/paths/events/tag-details.json
+++ b/paths/events/tag-details.json
@@ -40,12 +40,10 @@
                 }
               }
             },
-            "example": [
-              {
-                "key": "ice_cream",
-                "totalValues": 6
-              }
-            ]
+            "example": {
+              "key": "ice_cream",
+              "totalValues": 6
+            }
           }
         }
       },


### PR DESCRIPTION
I truly don't know how this was missed, but the example for `tag-details` was an array when it's supposed to be an object.