### PR TITLE
feat: Workflow to automatically update sentry-docs

### DIFF
--- a/.github/workflows/sentry-docs.yml
+++ b/.github/workflows/sentry-docs.yml
@@ -1,0 +1,47 @@
+name: openapi-diff
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  check-diff:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout getsentry/sentry-api-schema
+        uses: actions/checkout@v2
+        with:
+          ref: 'main'
+          path: sentry-api-schema
+
+      - name: Getsentry Token
+        id: getsentry
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+      - name: Checkout getsentry/sentry-docs
+        uses: actions/checkout@v2
+        with:
+          ref: 'master'
+          repository: getsentry/sentry-docs
+          path: sentry-docs
+          token: ${{ steps.getsentry.outputs.token }}
+
+      - name: Copy latest SHA into getsentry/sentry-docs
+        run: |
+          cd sentry-api-schema
+          PREV_SHA=$(git rev-parse HEAD^1)
+          HEAD=$(git rev-parse HEAD)
+          cd ../sentry-docs
+          sed -i "" 's|'"$PREV_SHA"'|'"$HEAD"'|g' src/gatsby/utils/resolveOpenAPI.ts
+
+      - name: Git Commit & Push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          repository: sentry-docs
+          branch: master
+          commit_message: Latest SHA from getsentry/sentry-api-schema
+          commit_user_email: bot@getsentry.com
+          commit_user_name: openapi-getsentry-bot

--- a/.github/workflows/sentry-docs.yml
+++ b/.github/workflows/sentry-docs.yml
@@ -15,7 +15,7 @@ jobs:
           path: sentry-api-schema
 
       - name: Getsentry Token
-        id: getsentry
+        id: getsentry-token
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
@@ -27,7 +27,7 @@ jobs:
           ref: 'master'
           repository: getsentry/sentry-docs
           path: sentry-docs
-          token: ${{ steps.getsentry.outputs.token }}
+          token: ${{ steps.getsentry-token.outputs.token }}
 
       - name: Copy latest SHA into getsentry/sentry-docs
         run: |


### PR DESCRIPTION
## Objective
We want to automatically update sentry-docs when a change is made to API docs in sentry.

This will trigger on push to master and update `getsentry/sentry-docs` with the latest SHA.

## Test Plan

When this commit gets merged, it should trigger this workflow and we can manually verify if the SHA got updated in `sentry-docs`