### PR TITLE
feat(actions): Dispatch action to sentry-docs

### DIFF
--- a/.github/workflows/sentry-docs.yml
+++ b/.github/workflows/sentry-docs.yml
@@ -1,47 +1,34 @@
-name: openapi-diff
+name: sentry-docs
 on:
   push:
     branches:
       - 'main'
 
 jobs:
-  check-diff:
+  
+  bump:
+    if: ${{ github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout getsentry/sentry-api-schema
-        uses: actions/checkout@v2
-        with:
-          ref: 'main'
-          path: sentry-api-schema
-
-      - name: Getsentry Token
+      - name: getsentry token
         id: getsentry-token
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      - name: Checkout getsentry/sentry-docs
-        uses: actions/checkout@v2
+      # Notify sentry-docs
+      - name: Dispatch to sentry-docs
+        uses: actions/github-script@v3
         with:
-          ref: 'master'
-          repository: getsentry/sentry-docs
-          path: sentry-docs
-          token: ${{ steps.getsentry-token.outputs.token }}
-
-      - name: Copy latest SHA into getsentry/sentry-docs
-        run: |
-          cd sentry-api-schema
-          PREV_SHA=$(git rev-parse HEAD^1)
-          HEAD=$(git rev-parse HEAD)
-          cd ../sentry-docs
-          sed -i "" 's|'"$PREV_SHA"'|'"$HEAD"'|g' src/gatsby/utils/resolveOpenAPI.ts
-
-      - name: Git Commit & Push
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          repository: sentry-docs
-          branch: master
-          commit_message: Latest SHA from getsentry/sentry-api-schema
-          commit_user_email: bot@getsentry.com
-          commit_user_name: openapi-getsentry-bot
+          github-token: ${{ steps.getsentry-token.outputs.token }}
+          script: |
+            github.actions.createWorkflowDispatch({
+              owner: 'getsentry',
+              repo: 'sentry-docs',
+              workflow_id: 'bump-openapi.yml',
+              ref: 'master',
+              inputs: {
+                'sentry-api-schema-sha': '${{ github.sha }}',
+              }
+            })

--- a/.github/workflows/sentry-docs.yml
+++ b/.github/workflows/sentry-docs.yml
@@ -7,21 +7,13 @@ on:
 jobs:
   
   bump:
-    if: ${{ github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
     steps:
-      - name: getsentry token
-        id: getsentry-token
-        uses: getsentry/action-github-app-token@v1
-        with:
-          app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
-          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
-
       # Notify sentry-docs
       - name: Dispatch to sentry-docs
         uses: actions/github-script@v3
         with:
-          github-token: ${{ steps.getsentry-token.outputs.token }}
+          github-token: ${{ secrets.GH_SENTRY_BOT_PAT }}
           script: |
             github.actions.createWorkflowDispatch({
               owner: 'getsentry',


### PR DESCRIPTION
## Objective
Refactor our existing bump SHA action in sentry-api-docs, so that we have something similar to ./bin/bump-sentry in getsentry.

This workflow triggers a workflow dispatch event and sends the SHA of the latest master.

Concurrent PR: https://github.com/getsentry/sentry-docs/pull/2563