### PR TITLE
Replace owners-ingest team with ingest team

### DIFF
--- a/api_ownership_stats_dont_modify.json
+++ b/api_ownership_stats_dont_modify.json
@@ -1,5 +1,5 @@
 {
-    "owners-ingest": {
+    "ingest": {
         "block_start": 2,
         "public": [],
         "private": [],


### PR DESCRIPTION
We are working with the Ingest team on consolidating the [owners-ingest team](https://github.com/orgs/getsentry/teams/owners-ingest) and [ingest team](https://github.com/orgs/getsentry/teams/ingest) in GitHub, owners-ingest will be deprecated.

Related PR in security-as-code: https://github.com/getsentry/security-as-code/pull/477