### PR TITLE
ref: Update `SetupWizard` API ownership

### DIFF
--- a/api_ownership_stats_dont_modify.json
+++ b/api_ownership_stats_dont_modify.json
@@ -578,7 +578,9 @@
         "block_start": 577,
         "public": [],
         "private": [
-            "SourceMapDebugBlueThunderEditionEndpoint::GET"
+            "SourceMapDebugBlueThunderEditionEndpoint::GET",
+            "SetupWizard::DELETE",
+            "SetupWizard::GET"
         ],
         "experimental": [],
         "unknown": [
@@ -586,8 +588,6 @@
             "ProjectArtifactBundleFileDetailsEndpoint::GET",
             "ProjectArtifactBundleFilesEndpoint::GET",
             "ProjectArtifactLookupEndpoint::GET",
-            "SetupWizard::DELETE",
-            "SetupWizard::GET",
             "SourceMapsEndpoint::DELETE",
             "SourceMapsEndpoint::GET"
         ]


### PR DESCRIPTION
Setting it to private of team-web-sdk-frontend.

We'd like to make it private for now to give us some more freedom because we'll need to make changes to the endpoint to adapt for hybrid cloud and use org tokens.