### PR TITLE
feat(release): Replace release bot with GH app

### DIFF
--- a/.github/workflows/cascade-to-sentry-docs.yml
+++ b/.github/workflows/cascade-to-sentry-docs.yml
@@ -8,7 +8,13 @@ jobs:
   cascade-to-sentry-docs:
     runs-on: ubuntu-latest
     steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
       - name: Cascade to sentry-docs
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         run: gh workflow run "Bump API Schema SHA" -R getsentry/sentry-docs


### PR DESCRIPTION
We are deprecating the `release-bot`, since this workflow has nothing to do with release, I'm replacing it with the `getSantry` GH app with is a generic app we use for automation

Functionality wise, there will be no difference. 

More details: https://www.notion.so/sentry/DACI-Replace-GitHub-bot-accounts-with-GitHub-Apps-getsentry-release-15109965d1204a91b9be71c49e8b66e0?pvs=4