### PR TITLE
fix(workflow): Replace `getSantry` with dedicated GH app for api schema workflow

### DIFF
--- a/.github/workflows/cascade-to-sentry-docs.yml
+++ b/.github/workflows/cascade-to-sentry-docs.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ vars.SENTRY_API_SCHEMA_UPDATER_APP_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_API_SCHEMA_UPDATER_PRIVATE_KEY }}

--- a/.github/workflows/cascade-to-sentry-docs.yml
+++ b/.github/workflows/cascade-to-sentry-docs.yml
@@ -12,8 +12,8 @@ jobs:
         id: token
         uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
-          app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
-          private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.SENTRY_API_SCHEMA_UPDATER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_API_SCHEMA_UPDATER_PRIVATE_KEY }}
           repositories: sentry-docs
       - name: Cascade to sentry-docs
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
We added the new default rulesets that requires all commit to go through PRs and that breaks this workflow.
Added the following changes to fix it
- created a new dedicated github app for this
- added the github app to allowlist in the ruleset
- update the workflow to use the new github app instead of `getSantry`
- added the app-id and private key through org secrets and variables