### PR TITLE
feat: add auto-generated Zod schemas via Hey API plugin

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,15 +1,26 @@
 import { createClient } from "@hey-api/openapi-ts";
-import { cpSync, appendFileSync } from "node:fs";
+import { cpSync, appendFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// 1. Generate TypeScript client from OpenAPI spec
+// 1. Generate TypeScript client from OpenAPI spec (including Zod schemas).
+//    When `plugins` is specified, the defaults (TypeScript + SDK + client) are
+//    no longer implicit — list them explicitly so the previous output is
+//    preserved alongside the new Zod schemas.
 await createClient({
   input: "./openapi-derefed.json",
   output: "src",
+  plugins: [
+    "@hey-api/typescript",
+    "@hey-api/sdk",
+    {
+      name: "zod",
+      compatibilityVersion: 3,
+    },
+  ],
 });
 
 // 2. Copy hand-written pagination utilities into the generated src/ directory
@@ -36,6 +47,17 @@ appendFileSync(
   ].join("\n"),
 );
 
-// 5. Bundle into a single JS file and emit type declarations
+// 5. Create a standalone Zod entry point that re-exports the generated schemas.
+//    This lets consumers import from "@sentry/api/zod" without pulling zod into
+//    code that only needs the SDK types and functions.
+writeFileSync(
+  "src/zod.ts",
+  'export * from "./zod.gen.ts";\n',
+);
+
+// 6. Bundle into JS files and emit type declarations.
+//    The main entry stays self-contained (zero runtime deps).
+//    The Zod entry externalises "zod" — consumers provide it themselves.
 execSync("bun build src/index.ts --outdir dist", { stdio: "inherit" });
+execSync('bun build src/zod.ts --outdir dist --external zod', { stdio: "inherit" });
 execSync("tsc --emitDeclarationOnly", { stdio: "inherit" });

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,14 @@
         "@types/bun": "^1.3.13",
         "@types/node": "^22",
         "typescript": "^5.9.3",
+        "zod": "^3.24.0",
       },
+      "peerDependencies": {
+        "zod": "^3.24.0",
+      },
+      "optionalPeers": [
+        "zod",
+      ],
     },
   },
   "packages": {
@@ -126,6 +133,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "nypm/citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
   }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,14 @@
     "typecheck": "tsc -p tsconfig.test.json"
   },
   "exports": {
-    "import": "./dist/index.js",
-    "types": "./dist/index.d.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./zod": {
+      "import": "./dist/zod.js",
+      "types": "./dist/zod.d.ts"
+    }
   },
   "homepage": "https://docs.sentry.io/api/",
   "publishConfig": {
@@ -36,11 +42,20 @@
   "bugs": {
     "url": "https://github.com/getsentry/sentry-api-schema/issues"
   },
+  "peerDependencies": {
+    "zod": "^3.24.0"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@hey-api/openapi-ts": "0.91.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^22",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "zod": "^3.24.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Add auto-generated Zod v3 schemas from the OpenAPI spec using Hey API's built-in Zod plugin. The schemas are exported from a separate `@sentry/api/zod` subpath entry point so existing consumers are completely unaffected — only those who opt in by importing from `@sentry/api/zod` will pull in the zod dependency.

Both the CLI (`getsentry/cli`) and MCP server (`getsentry/sentry-mcp`) currently maintain hand-written Zod schemas for Sentry API responses. This change enables them to migrate to auto-generated schemas that stay in sync with the OpenAPI spec automatically.

### Usage

```ts
import { zAlertRule, zOrganization } from "@sentry/api/zod";

const parsed = zOrganization.parse(rawData);
```

### What changed

- **`build.mjs`**: Enable the `zod` plugin with `compatibilityVersion: 3` (Zod v3 syntax, matching both consumer repos). Default plugins (`@hey-api/typescript`, `@hey-api/sdk`) are listed explicitly since adding `plugins` overrides defaults.
- **`build.mjs`**: Create `src/zod.ts` entry point and bundle it to `dist/zod.js` with `zod` externalized (not bundled — consumers provide their own zod).
- **`package.json`**: Add `./zod` subpath export, `zod` as optional peer dependency, and `zod` as dev dependency for build-time resolution.

### Testing

`bun run build && bun run typecheck && bun test` — all 28 tests pass, typecheck clean, `npm pack` produces valid package.

<!--
## Plan
1. Research Hey API Zod plugin docs — found `compatibilityVersion: 3` option for Zod v3 output
2. Analyzed CLI repo: uses zod ^3.24.0, has 12 files with hand-written Zod schemas for API validation
3. Analyzed MCP repo: uses zod ^3.25.67, has 1381-line hand-written schema.ts file
4. Added zod plugin to build.mjs createClient config with compatibilityVersion: 3
5. Listed default plugins explicitly (required when plugins array is provided)
6. Created separate dist/zod.js entry point with zod externalized
7. Added package.json exports, peer dependency, and dev dependency
8. Verified build, typecheck, and all 28 tests pass
-->