### PR TITLE
fix: remove dead alert-rules references after endpoint removal from spec

### DIFF
--- a/scripts/generate-pagination.mjs
+++ b/scripts/generate-pagination.mjs
@@ -73,11 +73,8 @@ const typesSource = readFileSync(TYPES_PATH, "utf8");
  * before being added.
  */
 const PAGINATED_BUT_UNMARKED = new Set([
-  // /organizations/{org}/alert-rules/ — used by getsentry/cli's
-  // listMetricAlertsPaginated. The runtime accepts `cursor` and `per_page`
-  // (CLI proves it via raw apiRequestToRegion); the spec only declares the
-  // path param. Remove this entry once the upstream OpenAPI spec is fixed.
-  "GET /api/0/organizations/{organization_id_or_slug}/alert-rules/",
+  // Add entries here for endpoints that paginate via Link-header cursors
+  // but whose OpenAPI spec doesn't declare a `cursor` query parameter.
 ]);
 
 /**

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -401,22 +401,4 @@ describe("generated wrappers (pagination.gen.ts)", () => {
     expect(keys).not.toContain("paginateUpTo_listClickedNodes");
   });
 
-  test("allow-list: emits wrappers for spec-incomplete paginated ops", () => {
-    // /organizations/{org}/alert-rules/ runtime-supports cursor pagination
-    // but its OpenAPI spec doesn't declare the cursor parameter. The
-    // PAGINATED_BUT_UNMARKED allow-list in the generator forces wrappers
-    // to be emitted anyway. Without this entry, the CLI's
-    // listMetricAlertsPaginated call site can't be migrated.
-    const indexModule = require("../src/index") as Record<string, unknown>;
-    const keys = Object.keys(indexModule);
-    expect(keys).toContain(
-      "fetchPage_deprecatedListAnOrganization_sMetricAlertRules",
-    );
-    expect(keys).toContain(
-      "paginateAll_deprecatedListAnOrganization_sMetricAlertRules",
-    );
-    expect(keys).toContain(
-      "paginateUpTo_deprecatedListAnOrganization_sMetricAlertRules",
-    );
-  });
 });

--- a/test/typecheck.ts
+++ b/test/typecheck.ts
@@ -12,7 +12,6 @@
  */
 
 import {
-  fetchPage_deprecatedListAnOrganization_sMetricAlertRules,
   fetchPage_listAnOrganization_sIssues,
   fetchPage_listAnOrganization_sProjects,
   fetchPage_listClickedNodes,
@@ -139,22 +138,6 @@ async function perPageAcceptedEvenWhenSpecOmitsIt() {
 }
 
 // =====================================================================
-// Allow-list: spec-incomplete operations get wrappers anyway
-// =====================================================================
-
-async function metricAlertsWrapperExists() {
-  // /alert-rules/ has `query?: never` in the spec (no cursor declared),
-  // but the PAGINATED_BUT_UNMARKED allow-list emits wrappers. Callers
-  // can pass per_page (added by PaginationQuery) and cursor is managed.
-  const result = await fetchPage_deprecatedListAnOrganization_sMetricAlertRules({
-    ...config,
-    path: { organization_id_or_slug: "my-org" },
-    query: { per_page: 50 },
-  });
-  void result.data;
-}
-
-// =====================================================================
 // keepCursorOnOvershoot — opt-in option for endpoints with no per_page
 // =====================================================================
 
@@ -185,5 +168,4 @@ void paginateAllHappyPath;
 void paginateUpToHappyPath;
 void fetchPageCompoundOp;
 void perPageAcceptedEvenWhenSpecOmitsIt;
-void metricAlertsWrapperExists;
 void paginateUpToKeepCursorOnOvershoot;


### PR DESCRIPTION
The `alert-rules` endpoint (`GET /api/0/organizations/{org}/alert-rules/`) was removed from `openapi-derefed.json` but three files still referenced it, causing the `typecheck` CI step to fail on `main` ([run](https://github.com/getsentry/sentry-api-schema/actions/runs/26599969509/job/78501016661)).

Removes the stale `PAGINATED_BUT_UNMARKED` allow-list entry in the pagination generator, the compile-time type-check function, and the smoke test that asserted the wrapper existed.

## Testing

`bun run build && bun run typecheck && bun test` — all pass locally.

<!--
## Plan
1. Remove the `fetchPage_deprecatedListAnOrganization_sMetricAlertRules` import and `metricAlertsWrapperExists()` function from test/typecheck.ts
2. Remove the stale allow-list entry for alert-rules from scripts/generate-pagination.mjs (keep the Set infrastructure for future entries)
3. Remove the smoke test asserting the wrapper exists from test/smoke.test.ts
4. Verify build + typecheck + tests all pass
-->