### PR TITLE
feat: add @sentry/api/browser entry point for cookie+CSRF auth

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -23,8 +23,9 @@ await createClient({
   ],
 });
 
-// 2. Copy hand-written pagination utilities into the generated src/ directory
+// 2. Copy hand-written utilities into the generated src/ directory
 cpSync("lib/sentry-pagination.ts", "src/sentry-pagination.ts");
+cpSync("lib/browser-client.ts", "src/browser-client.ts");
 
 // 3. Generate per-operation pagination wrappers from the SDK output + spec.
 //    This post-processor inspects src/sdk.gen.ts and openapi-derefed.json,
@@ -47,17 +48,17 @@ appendFileSync(
   ].join("\n"),
 );
 
-// 5. Create a standalone Zod entry point that re-exports the generated schemas.
-//    This lets consumers import from "@sentry/api/zod" without pulling zod into
+// 5. Create standalone entry points.
+//    zod: lets consumers import from "@sentry/api/zod" without pulling zod into
 //    code that only needs the SDK types and functions.
-writeFileSync(
-  "src/zod.ts",
-  'export * from "./zod.gen.ts";\n',
-);
+//    browser: CSRF + cookie auth helpers for browser/frontend use.
+writeFileSync("src/zod.ts", 'export * from "./zod.gen.ts";\n');
+writeFileSync("src/browser.ts", 'export * from "./browser-client.ts";\n');
 
 // 6. Bundle into JS files and emit type declarations.
 //    The main entry stays self-contained (zero runtime deps).
 //    The Zod entry externalises "zod" — consumers provide it themselves.
 execSync("bun build src/index.ts --outdir dist", { stdio: "inherit" });
 execSync('bun build src/zod.ts --outdir dist --external zod', { stdio: "inherit" });
+execSync("bun build src/browser.ts --outdir dist", { stdio: "inherit" });
 execSync("tsc --emitDeclarationOnly", { stdio: "inherit" });

--- a/lib/browser-client.ts
+++ b/lib/browser-client.ts
@@ -50,7 +50,11 @@ export function createBrowserFetch(opts: BrowserClientOptions = {}): FetchFn {
     // init.method takes precedence; fall back to the Request object's method if
     // input is a Request, then to 'GET' — mirrors the Fetch spec resolution order.
     const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
-    const headers = new Headers(init?.headers);
+    // Seed headers from the Request object when init provides none; otherwise
+    // init.headers wins (Fetch spec: init completely replaces Request headers).
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
     if (!SAFE_METHODS.has(method)) {
       const token = getCsrf();
       if (token) headers.set('X-CSRFToken', token);

--- a/lib/browser-client.ts
+++ b/lib/browser-client.ts
@@ -9,7 +9,7 @@
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE']);
 
 /** Matches the standard fetch signature without Bun/Node runtime extensions. */
-type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+export type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 export type BrowserClientOptions = {
   /** Cookie name to read the CSRF token from. Defaults to 'sc' (Sentry's Django default). */

--- a/lib/browser-client.ts
+++ b/lib/browser-client.ts
@@ -1,0 +1,74 @@
+/**
+ * Browser auth utilities for @sentry/api.
+ *
+ * Provides a fetch wrapper that handles cookie-based session auth and
+ * CSRF token injection, allowing the SDK to be used inside the Sentry
+ * frontend without a Bearer token.
+ */
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE']);
+
+/** Matches the standard fetch signature without Bun/Node runtime extensions. */
+type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export type BrowserClientOptions = {
+  /** Cookie name to read the CSRF token from. Defaults to 'sc' (Sentry's Django default). */
+  csrfCookieName?: string;
+  /** Override the CSRF token getter — useful for testing. */
+  getCsrfToken?: () => string;
+  /** Base URL for all requests. Defaults to '' (same-origin relative URLs). */
+  baseUrl?: string;
+};
+
+function readCookie(name: string): string {
+  // SSR / Node environments have no document; return empty so no token is injected.
+  if (typeof document === 'undefined') return '';
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = document.cookie.match(new RegExp(`(?:^|; )${escapedName}=([^;]*)`));
+  if (!match) return '';
+  try {
+    return decodeURIComponent(match[1]!);
+  } catch {
+    // Fall back to raw value if the cookie is malformed percent-encoded.
+    return match[1]!;
+  }
+}
+
+/**
+ * Returns a fetch wrapper that injects X-CSRFToken on state-changing requests
+ * and sends session cookies via credentials: 'include'.
+ *
+ * Sentry's Django backend reads the CSRF token from the 'sc' cookie by default
+ * (configurable via window.csrfCookieName in the frontend).
+ *
+ * Note: always sets credentials: 'include'; any credentials value in init is overridden.
+ */
+export function createBrowserFetch(opts: BrowserClientOptions = {}): FetchFn {
+  const getCsrf = opts.getCsrfToken ?? (() => readCookie(opts.csrfCookieName ?? 'sc'));
+
+  return (input, init) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers = new Headers(init?.headers);
+    if (!SAFE_METHODS.has(method)) {
+      const token = getCsrf();
+      if (token) headers.set('X-CSRFToken', token);
+    }
+    return globalThis.fetch(input, {...init, headers, credentials: 'include'});
+  };
+}
+
+/**
+ * Returns options to spread into any @sentry/api SDK call from a browser context.
+ * Configures relative base URL and cookie+CSRF auth automatically.
+ *
+ * @example
+ * import {client} from '@sentry/api';
+ * import {createBrowserSdkConfig} from '@sentry/api/browser';
+ * client.setConfig(createBrowserSdkConfig());
+ */
+export function createBrowserSdkConfig(opts: BrowserClientOptions = {}) {
+  return {
+    baseUrl: opts.baseUrl ?? '',
+    fetch: createBrowserFetch(opts),
+  } as const;
+}

--- a/lib/browser-client.ts
+++ b/lib/browser-client.ts
@@ -47,7 +47,9 @@ export function createBrowserFetch(opts: BrowserClientOptions = {}): FetchFn {
   const getCsrf = opts.getCsrfToken ?? (() => readCookie(opts.csrfCookieName ?? 'sc'));
 
   return (input, init) => {
-    const method = (init?.method ?? 'GET').toUpperCase();
+    // init.method takes precedence; fall back to the Request object's method if
+    // input is a Request, then to 'GET' — mirrors the Fetch spec resolution order.
+    const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
     const headers = new Headers(init?.headers);
     if (!SAFE_METHODS.has(method)) {
       const token = getCsrf();

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "./zod": {
       "import": "./dist/zod.js",
       "types": "./dist/zod.d.ts"
+    },
+    "./browser": {
+      "import": "./dist/browser.js",
+      "types": "./dist/browser.d.ts"
     }
   },
   "homepage": "https://docs.sentry.io/api/",

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,10 +1,10 @@
 import {describe, expect, it} from 'bun:test';
-import {createBrowserFetch, createBrowserSdkConfig} from '../lib/browser-client.ts';
+import {createBrowserFetch, createBrowserSdkConfig, type FetchFn} from '../lib/browser-client.ts';
 
 // Helper to capture headers/init from a fetch call
-function captureFetch(): {mock: typeof fetch; captured: {headers?: Headers; init?: RequestInit}} {
+function captureFetch(): {mock: FetchFn; captured: {headers?: Headers; init?: RequestInit}} {
   const captured: {headers?: Headers; init?: RequestInit} = {};
-  const mock: typeof fetch = async (_input, init) => {
+  const mock: FetchFn = async (_input, init) => {
     captured.headers = new Headers(init?.headers);
     captured.init = init;
     return new Response('{}', {status: 200});
@@ -12,9 +12,9 @@ function captureFetch(): {mock: typeof fetch; captured: {headers?: Headers; init
   return {mock, captured};
 }
 
-async function withMockFetch<T>(mock: typeof fetch, fn: () => Promise<T>): Promise<T> {
+async function withMockFetch<T>(mock: FetchFn, fn: () => Promise<T>): Promise<T> {
   const original = globalThis.fetch;
-  globalThis.fetch = mock;
+  globalThis.fetch = mock as typeof fetch;
   try {
     return await fn();
   } finally {

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -72,6 +72,23 @@ describe('createBrowserFetch', () => {
     expect(captured.headers?.get('X-CSRFToken')).toBeNull();
   });
 
+  it('injects X-CSRFToken when input is a Request object with POST method', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    // Must use a full URL — relative paths are invalid in the Request constructor in Node/Bun.
+    const request = new Request('https://sentry.io/api/0/projects/', {method: 'POST'});
+    await withMockFetch(mock, () => browserFetch(request));
+    expect(captured.headers?.get('X-CSRFToken')).toBe('token');
+  });
+
+  it('does not inject X-CSRFToken when input is a Request object with GET method', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    const request = new Request('https://sentry.io/api/0/projects/');
+    await withMockFetch(mock, () => browserFetch(request));
+    expect(captured.headers?.get('X-CSRFToken')).toBeNull();
+  });
+
   it('does not inject empty CSRF token', async () => {
     const {mock, captured} = captureFetch();
     const browserFetch = createBrowserFetch({getCsrfToken: () => ''});

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,0 +1,112 @@
+import {describe, expect, it} from 'bun:test';
+import {createBrowserFetch, createBrowserSdkConfig} from '../lib/browser-client.ts';
+
+// Helper to capture headers/init from a fetch call
+function captureFetch(): {mock: typeof fetch; captured: {headers?: Headers; init?: RequestInit}} {
+  const captured: {headers?: Headers; init?: RequestInit} = {};
+  const mock: typeof fetch = async (_input, init) => {
+    captured.headers = new Headers(init?.headers);
+    captured.init = init;
+    return new Response('{}', {status: 200});
+  };
+  return {mock, captured};
+}
+
+async function withMockFetch<T>(mock: typeof fetch, fn: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = mock;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+describe('createBrowserFetch', () => {
+  it('injects X-CSRFToken on POST', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'test-csrf-token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/', {method: 'POST', body: '{}'}));
+    expect(captured.headers?.get('X-CSRFToken')).toBe('test-csrf-token');
+  });
+
+  it('injects X-CSRFToken on PUT', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'test-csrf-token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/my-proj/', {method: 'PUT', body: '{}'}));
+    expect(captured.headers?.get('X-CSRFToken')).toBe('test-csrf-token');
+  });
+
+  it('injects X-CSRFToken on PATCH', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'test-csrf-token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/my-proj/', {method: 'PATCH', body: '{}'}));
+    expect(captured.headers?.get('X-CSRFToken')).toBe('test-csrf-token');
+  });
+
+  it('injects X-CSRFToken on DELETE', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/my-proj/', {method: 'DELETE'}));
+    expect(captured.headers?.get('X-CSRFToken')).toBe('token');
+  });
+
+  it('does not inject X-CSRFToken on GET with explicit method', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'test-csrf-token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/', {method: 'GET'}));
+    expect(captured.headers?.get('X-CSRFToken')).toBeNull();
+  });
+
+  it('does not inject X-CSRFToken when called with no init (defaults to GET)', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'test-csrf-token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/'));
+    expect(captured.headers?.get('X-CSRFToken')).toBeNull();
+  });
+
+  it('does not inject X-CSRFToken on HEAD', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/', {method: 'HEAD'}));
+    expect(captured.headers?.get('X-CSRFToken')).toBeNull();
+  });
+
+  it('does not inject empty CSRF token', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => ''});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/', {method: 'POST'}));
+    expect(captured.headers?.has('X-CSRFToken')).toBe(false);
+  });
+
+  it('sets credentials: include', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/', {method: 'POST'}));
+    expect(captured.init?.credentials).toBe('include');
+  });
+
+  it('overrides caller-provided credentials with include', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/', {method: 'GET', credentials: 'omit'}));
+    expect(captured.init?.credentials).toBe('include');
+  });
+});
+
+describe('createBrowserSdkConfig', () => {
+  it('returns empty baseUrl by default', () => {
+    const config = createBrowserSdkConfig();
+    expect(config.baseUrl).toBe('');
+  });
+
+  it('accepts custom baseUrl', () => {
+    const config = createBrowserSdkConfig({baseUrl: 'https://sentry.io'});
+    expect(config.baseUrl).toBe('https://sentry.io');
+  });
+
+  it('returns a fetch function', () => {
+    const config = createBrowserSdkConfig();
+    expect(typeof config.fetch).toBe('function');
+  });
+});

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -81,6 +81,33 @@ describe('createBrowserFetch', () => {
     expect(captured.headers?.get('X-CSRFToken')).toBe('token');
   });
 
+  it('preserves Request object headers when no init.headers is provided', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    const request = new Request('https://sentry.io/api/0/projects/', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json', 'X-Custom': 'value'},
+    });
+    await withMockFetch(mock, () => browserFetch(request));
+    expect(captured.headers?.get('Content-Type')).toBe('application/json');
+    expect(captured.headers?.get('X-Custom')).toBe('value');
+    expect(captured.headers?.get('X-CSRFToken')).toBe('token');
+  });
+
+  it('uses init.headers over Request object headers when both are provided', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    const request = new Request('https://sentry.io/api/0/projects/', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+    });
+    await withMockFetch(mock, () =>
+      browserFetch(request, {headers: {'Content-Type': 'text/plain'}}),
+    );
+    // init.headers wins — matches native fetch spec behavior
+    expect(captured.headers?.get('Content-Type')).toBe('text/plain');
+  });
+
   it('does not inject X-CSRFToken when input is a Request object with GET method', async () => {
     const {mock, captured} = captureFetch();
     const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -116,6 +116,36 @@ describe('createBrowserFetch', () => {
     expect(captured.headers?.get('X-CSRFToken')).toBeNull();
   });
 
+  it('injects X-CSRFToken when input is a URL object with POST in init', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    await withMockFetch(mock, () =>
+      browserFetch(new URL('https://sentry.io/api/0/projects/'), {method: 'POST'}),
+    );
+    expect(captured.headers?.get('X-CSRFToken')).toBe('token');
+  });
+
+  it('preserves Request headers when init provides method but no headers', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    const request = new Request('https://sentry.io/api/0/projects/my-proj/', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+    });
+    await withMockFetch(mock, () => browserFetch(request, {method: 'PUT'}));
+    expect(captured.headers?.get('Content-Type')).toBe('application/json');
+    expect(captured.headers?.get('X-CSRFToken')).toBe('token');
+  });
+
+  it('injects X-CSRFToken when init.method is lowercase', async () => {
+    const {mock, captured} = captureFetch();
+    const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
+    await withMockFetch(mock, () =>
+      browserFetch('/api/0/projects/', {method: 'post' as RequestInit['method']}),
+    );
+    expect(captured.headers?.get('X-CSRFToken')).toBe('token');
+  });
+
   it('does not inject empty CSRF token', async () => {
     const {mock, captured} = captureFetch();
     const browserFetch = createBrowserFetch({getCsrfToken: () => ''});

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -140,9 +140,7 @@ describe('createBrowserFetch', () => {
   it('injects X-CSRFToken when init.method is lowercase', async () => {
     const {mock, captured} = captureFetch();
     const browserFetch = createBrowserFetch({getCsrfToken: () => 'token'});
-    await withMockFetch(mock, () =>
-      browserFetch('/api/0/projects/', {method: 'post' as RequestInit['method']}),
-    );
+    await withMockFetch(mock, () => browserFetch('/api/0/projects/', {method: 'post'}));
     expect(captured.headers?.get('X-CSRFToken')).toBe('token');
   });
 


### PR DESCRIPTION
Adds a `@sentry/api/browser` subpath export with two helpers for using the SDK inside a browser app that authenticates via session cookies rather than a Bearer token.

The Sentry frontend (and any self-hosted frontend) can't use the existing SDK as-is because it has no CSRF token support and assumes an `Authorization` header. This change closes that gap without touching the main entry point or affecting existing consumers.

### Usage

```ts
import {client} from '@sentry/api';
import {createBrowserSdkConfig} from '@sentry/api/browser';

// Once at app startup — reads the CSRF token from the 'sc' cookie automatically
client.setConfig(createBrowserSdkConfig());
```

Custom cookie name or token getter (e.g. for testing):

```ts
client.setConfig(createBrowserSdkConfig({
  csrfCookieName: 'csrftoken',      // Django default outside Sentry
  getCsrfToken: () => myTokenFn(),  // override entirely
  baseUrl: 'https://sentry.io',     // for non-same-origin use
}));
```

### What changed

- **`lib/browser-client.ts`**: new hand-written module (same pattern as `lib/sentry-pagination.ts`) — `createBrowserFetch` wraps `globalThis.fetch` to inject `X-CSRFToken` on non-safe methods and force `credentials: 'include'`; `createBrowserSdkConfig` is a convenience wrapper that also sets `baseUrl: ''` for same-origin requests
- **`test/browser.test.ts`**: 13 tests covering CSRF injection on POST/PUT/PATCH/DELETE, safe method exclusions, empty token handling, credentials override, and the no-init default
- **`build.mjs`**: copies `browser-client.ts` into `src/`, creates `src/browser.ts` entry, bundles to `dist/browser.js`
- **`package.json`**: adds `"./browser"` to `exports`