### PR TITLE
feat: normalize operationIds to short REST-conventional names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules
 dist
 src
 
+# normalized spec written by build step 0.5 (derived from openapi-derefed.json)
+openapi-normalized.json
+
 # caches
 .eslintcache
 .cache

--- a/build.mjs
+++ b/build.mjs
@@ -3,15 +3,24 @@ import { cpSync, appendFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { normalizeSpec } from "./lib/normalize-spec.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// 0.5 Normalize verbose English sentence operationIds to short REST-conventional
+//     identifiers (e.g. "List Your Organizations" → "listOrganizations").
+//     Writes a temporary openapi-normalized.json that the generator reads instead
+//     of the source spec. The source spec is never modified.
+//     OperationIds that are already identifiers (no spaces) are left untouched —
+//     those were set intentionally via @extend_schema(operation_id=...).
+normalizeSpec("./openapi-derefed.json", "./openapi-normalized.json");
 
 // 1. Generate TypeScript client from OpenAPI spec (including Zod schemas).
 //    When `plugins` is specified, the defaults (TypeScript + SDK + client) are
 //    no longer implicit — list them explicitly so the previous output is
 //    preserved alongside the new Zod schemas.
 await createClient({
-  input: "./openapi-derefed.json",
+  input: "./openapi-normalized.json",
   output: "src",
   plugins: [
     "@hey-api/typescript",

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -80,11 +80,21 @@ function normalizeOperationId(method, path) {
     parts[parts.length - 1] = singularize(parts[parts.length - 1]);
   }
 
+  if (parts.length === 0) {
+    // A path with no static segments (e.g. all {params}) cannot produce a
+    // meaningful name. This should not happen in a well-formed spec — if it
+    // does, the operationId should be set explicitly via @extend_schema.
+    throw new Error(
+      `normalizeOperationId: no static segments in path "${path}" (${method.toUpperCase()}). ` +
+        `Set operation_id explicitly via @extend_schema(operation_id=...).`,
+    );
+  }
+
   const resource = parts
     .map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1)))
     .join("");
 
-  return verb + (resource ? resource[0].toUpperCase() + resource.slice(1) : "");
+  return verb + resource[0].toUpperCase() + resource.slice(1);
 }
 
 /**
@@ -95,6 +105,8 @@ function normalizeOperationId(method, path) {
  * @param {string} outputPath - Path to write the normalized spec to
  */
 export function normalizeSpec(inputPath, outputPath) {
+  // JSON.parse produces a fresh object every call; mutations are safe and
+  // intentional — we rewrite operationIds in place before serialising.
   const spec = JSON.parse(readFileSync(inputPath, "utf8"));
 
   for (const [path, methods] of Object.entries(spec.paths ?? {})) {

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -140,20 +140,12 @@ const VERBS = {
  * @param {string} method - HTTP method (lowercase: "get", "post", …)
  * @param {string} path   - Full path, e.g. "/api/0/organizations/{org}/issues/{id}/"
  * @returns {string} Normalized identifier, e.g. "getOrganizationIssue"
- * @throws {Error} If the path has no static segments and cannot produce a name
+ * @throws {Error} If the path produces no usable resource name (no static
+ *   segments, or only separator-character segments)
  */
 export function normalizeOperationId(method, path) {
   const segments = parsePath(path);
   const statics = segments.filter((s) => !s.isParam);
-
-  if (statics.length === 0) {
-    throw new Error(
-      `normalizeOperationId: no static segments in path "${path}" ` +
-        `(${method.toUpperCase()}). Set operation_id explicitly via ` +
-        `@extend_schema(operation_id=...).`,
-    );
-  }
-
   const isDetail = segments.at(-1)?.isParam ?? false;
   const verb = method === "get" ? (isDetail ? "get" : "list") : (VERBS[method] ?? method);
 
@@ -169,6 +161,17 @@ export function normalizeOperationId(method, path) {
   const resource = parts
     .map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1)))
     .join("");
+
+  // Guard the real invariant: the assembled resource must be non-empty. This
+  // covers both a path with no static segments and one whose only static
+  // segments are separators (e.g. "/---/"), which camelCase to "".
+  if (resource.length === 0) {
+    throw new Error(
+      `normalizeOperationId: path "${path}" (${method.toUpperCase()}) has no ` +
+        `usable static segments. Set operation_id explicitly via ` +
+        `@extend_schema(operation_id=...).`,
+    );
+  }
 
   return verb + resource[0].toUpperCase() + resource.slice(1);
 }

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -43,15 +43,18 @@ const IRREGULAR = {
 export function singularize(word) {
   if (IRREGULAR[word]) return IRREGULAR[word];
   if (word.endsWith("ies")) return word.slice(0, -3) + "y";
-  // -shes → -sh, -ches → -ch, -xes → -x, -zes → -z, -ses → -se
+  // -shes → -sh, -ches → -ch, -xes → -x, -zes → -z
   if (/(?:sh|ch|x|z)es$/.test(word)) return word.slice(0, -2);
-  if (word.endsWith("ses") && !word.endsWith("sses")) return word.slice(0, -1);
-  // Skip -ss (class), -us (status), -is (analysis) — already singular.
+  // -ses → strip s (releases → release), but -sses → strip es (classes → class)
+  if (word.endsWith("sses")) return word.slice(0, -2);
+  if (word.endsWith("ses")) return word.slice(0, -1);
+  // Skip -ss (class), -us (status), -is (analysis), -as (alias) — already singular.
   if (
     word.endsWith("s") &&
     !word.endsWith("ss") &&
     !word.endsWith("us") &&
-    !word.endsWith("is")
+    !word.endsWith("is") &&
+    !word.endsWith("as")
   ) {
     const stem = word.slice(0, -1);
     return stem.length > 0 ? stem : word;

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -30,11 +30,20 @@ const IRREGULAR = {
   analyses: "analysis",
 };
 
+/**
+ * Returns the singular form of a lowercase English noun.
+ *
+ * Handles the most common patterns found in Sentry API path segments.
+ * Returns the word unchanged when no rule applies or when slicing would
+ * produce an empty string (e.g. the single-character input "s").
+ *
+ * @param {string} word - Lowercase noun, e.g. "issues", "activities"
+ * @returns {string} Singular form, e.g. "issue", "activity"
+ */
 export function singularize(word) {
   if (IRREGULAR[word]) return IRREGULAR[word];
   if (word.endsWith("ies")) return word.slice(0, -3) + "y";
-  // Regular -s removal: releases→release, teams→team, issues→issue.
-  // Skip -ss (class), -us (status), -is (analysis) — these are already singular.
+  // Skip -ss (class), -us (status), -is (analysis) — already singular.
   if (
     word.endsWith("s") &&
     !word.endsWith("ss") &&
@@ -42,7 +51,7 @@ export function singularize(word) {
     !word.endsWith("is")
   ) {
     const stem = word.slice(0, -1);
-    return stem.length > 0 ? stem : word; // never return empty string
+    return stem.length > 0 ? stem : word;
   }
   return word;
 }
@@ -71,9 +80,8 @@ export function parsePath(path) {
   return raw.map((s, i) => {
     const isParam = s.startsWith("{");
     return {
-      // kebab-case and snake_case → camelCase for static segments.
-      // Hyphens (events-timeseries) and underscores (stats_v2) are both treated
-      // as word separators. Params keep their raw form since they're discarded downstream.
+      // Hyphens and underscores are word separators for static segments (events-timeseries
+      // → eventsTimeseries, stats_v2 → statsV2). Params keep their raw form.
       value: isParam ? s : s.replace(/[-_]([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
       isParam,
       followedByParam: raw[i + 1]?.startsWith("{") ?? false,

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -60,24 +60,37 @@ export function singularize(word) {
 // Path parsing
 // ---------------------------------------------------------------------------
 
-/** Hyphens and underscores → camelCase: events-timeseries → eventsTimeseries */
-function toCamel(s) {
-  return s.replace(/[-_]([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
+/**
+ * Splits a path segment into its words on hyphen/underscore boundaries.
+ * Empty words from consecutive or trailing separators (e.g. "foo--bar") are
+ * dropped so downstream camelCasing never sees an empty string.
+ */
+function splitWords(s) {
+  return s.split(/[-_]/).filter(Boolean);
+}
+
+/** Joins words into camelCase: ["events", "timeseries"] → "eventsTimeseries" */
+function camelJoin(words) {
+  return words.map((w, i) => (i === 0 ? w : w[0].toUpperCase() + w.slice(1))).join("");
 }
 
 /**
- * Singularizes the last word of a hyphen/underscore-separated segment, then
- * converts the whole thing to camelCase.
+ * Converts a path segment to camelCase, optionally singularizing its last word.
  *
- * Singularizing the last word (not the full camelCase string) is critical for
+ * Singularizing the *last word* (not the full camelCase string) is critical for
  * compound segments: "release-threshold-statuses" must become
- * "releaseThresholdStatus", not "releaseThresholdStatuse". By splitting first,
- * singularize() receives "statuses" and can match the IRREGULAR table.
+ * "releaseThresholdStatus", not "releaseThresholdStatuse". Splitting first means
+ * singularize() receives the bare word "statuses" and can match the IRREGULAR table.
+ *
+ * Both `value` and `singularValue` go through this single path so they can never
+ * diverge on separator handling.
  */
-function toSingularCamel(s) {
-  const words = s.split(/[-_]/);
-  words[words.length - 1] = singularize(words[words.length - 1]);
-  return words.map((w, i) => (i === 0 ? w : w[0].toUpperCase() + w.slice(1))).join("");
+function segmentToCamel(s, { singular } = {}) {
+  const words = splitWords(s);
+  if (singular && words.length > 0) {
+    words[words.length - 1] = singularize(words[words.length - 1]);
+  }
+  return camelJoin(words);
 }
 
 /**
@@ -101,8 +114,8 @@ export function parsePath(path) {
   return raw.map((s, i) => {
     const isParam = s.startsWith("{");
     return {
-      value:         isParam ? s : toCamel(s),
-      singularValue: isParam ? s : toSingularCamel(s),
+      value:         isParam ? s : segmentToCamel(s),
+      singularValue: isParam ? s : segmentToCamel(s, { singular: true }),
       isParam,
       followedByParam: raw[i + 1]?.startsWith("{") ?? false,
     };

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -71,9 +71,10 @@ export function parsePath(path) {
   return raw.map((s, i) => {
     const isParam = s.startsWith("{");
     return {
-      // kebab-case → camelCase for static segments; params keep their raw form
-      // since their value is discarded by the statics filter downstream.
-      value: isParam ? s : s.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
+      // kebab-case and snake_case → camelCase for static segments.
+      // Hyphens (events-timeseries) and underscores (stats_v2) are both treated
+      // as word separators. Params keep their raw form since they're discarded downstream.
+      value: isParam ? s : s.replace(/[-_]([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
       isParam,
       followedByParam: raw[i + 1]?.startsWith("{") ?? false,
     };

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -1,0 +1,112 @@
+/**
+ * Normalizes verbose English sentence operationIds in the OpenAPI spec to short,
+ * REST-conventional camelCase identifiers.
+ *
+ * Rules:
+ *   GET  /…/collection/          → list{Resource}s
+ *   GET  /…/collection/{id}/     → get{Resource}       (singularize last segment)
+ *   POST /…/collection/          → create{Resource}    (singular — creating one item)
+ *   PUT/PATCH /…/resource/{id}/  → update{Resource}
+ *   DELETE /…/resource/{id}/     → delete{Resource}
+ *   DELETE /…/collection/        → delete{Resource}s   (bulk)
+ *
+ * Any operationId that is already an identifier (no spaces) is left untouched —
+ * those were set intentionally via @extend_schema(operation_id=...).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const IRREGULAR = {
+  activities: "activity",
+  queries: "query",
+  aliases: "alias",
+  indices: "index",
+  statuses: "status",
+  checkins: "checkin",
+  analyses: "analysis",
+};
+
+function singularize(word) {
+  if (IRREGULAR[word]) return IRREGULAR[word];
+  if (word.endsWith("ies")) return word.slice(0, -3) + "y";
+  // Regular -s removal: handles words like releases→release, teams→team, issues→issue.
+  // Avoid mutating words ending in -ss (class), -us (status), -is (analysis).
+  if (
+    word.endsWith("s") &&
+    !word.endsWith("ss") &&
+    !word.endsWith("us") &&
+    !word.endsWith("is")
+  ) {
+    return word.slice(0, -1);
+  }
+  return word;
+}
+
+function normalizeOperationId(method, path) {
+  const clean = path.replace(/^\/api\/0\//, "").replace(/\/$/, "");
+  const segments = clean.split("/");
+  const lastSeg = segments[segments.length - 1] ?? "";
+  const isDetail = lastSeg.startsWith("{");
+
+  const verb =
+    method === "get"
+      ? isDetail
+        ? "get"
+        : "list"
+      : method === "post"
+        ? "create"
+        : method === "put" || method === "patch"
+          ? "update"
+          : method === "delete"
+            ? "delete"
+            : method;
+
+  const parts = [];
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (seg.startsWith("{")) continue;
+
+    // Convert kebab-case to camelCase: events-timeseries → eventsTimeseries
+    const camel = seg.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
+
+    // Singularize segments that scope a specific resource (immediately followed by a param)
+    const nextSeg = segments[i + 1] ?? "";
+    const followedByParam = nextSeg.startsWith("{");
+    parts.push(followedByParam ? singularize(camel) : camel);
+  }
+
+  // Also singularize the last resource segment for detail GETs and creates
+  if ((isDetail || verb === "create") && parts.length > 0) {
+    parts[parts.length - 1] = singularize(parts[parts.length - 1]);
+  }
+
+  const resource = parts
+    .map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1)))
+    .join("");
+
+  return verb + (resource ? resource[0].toUpperCase() + resource.slice(1) : "");
+}
+
+/**
+ * Reads the spec at `inputPath`, rewrites all sentence-style operationIds to
+ * short REST-conventional names, and writes the result to `outputPath`.
+ *
+ * @param {string} inputPath  - Path to the source spec (e.g. openapi-derefed.json)
+ * @param {string} outputPath - Path to write the normalized spec to
+ */
+export function normalizeSpec(inputPath, outputPath) {
+  const spec = JSON.parse(readFileSync(inputPath, "utf8"));
+
+  for (const [path, methods] of Object.entries(spec.paths ?? {})) {
+    for (const [method, op] of Object.entries(methods)) {
+      if (typeof op !== "object" || !op.operationId) continue;
+      // Leave identifiers that have no spaces — they were set intentionally
+      if (!/\s/.test(op.operationId)) continue;
+      op.operationId = normalizeOperationId(method, path);
+    }
+  }
+
+  writeFileSync(outputPath, JSON.stringify(spec));
+}
+
+export { normalizeOperationId, singularize };

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -41,7 +41,8 @@ export function singularize(word) {
     !word.endsWith("us") &&
     !word.endsWith("is")
   ) {
-    return word.slice(0, -1);
+    const stem = word.slice(0, -1);
+    return stem.length > 0 ? stem : word; // never return empty string
   }
   return word;
 }
@@ -70,8 +71,8 @@ export function parsePath(path) {
   return raw.map((s, i) => {
     const isParam = s.startsWith("{");
     return {
-      // kebab-case → camelCase only matters for static segments, but computing
-      // it unconditionally keeps the shape uniform and the cost is negligible.
+      // kebab-case → camelCase for static segments; params keep their raw form
+      // since their value is discarded by the statics filter downstream.
       value: isParam ? s : s.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
       isParam,
       followedByParam: raw[i + 1]?.startsWith("{") ?? false,

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -57,7 +57,7 @@ function normalizeOperationId(method, path) {
     if (seg.startsWith("{")) continue;
 
     // kebab-case → camelCase: events-timeseries → eventsTimeseries
-    const camel = seg.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
+    const camel = seg.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
 
     // Segments immediately before a {param} scope a specific resource — singularize them.
     const followedByParam = (segments[i + 1] ?? "").startsWith("{");
@@ -79,8 +79,15 @@ function normalizeOperationId(method, path) {
   }
 
   const resource = parts
+    .filter((p) => p.length > 0) // drop empty strings from leading slashes on non-/api/0/ paths
     .map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1)))
     .join("");
+
+  if (resource.length === 0) {
+    throw new Error(
+      `normalizeOperationId: path "${path}" (${method.toUpperCase()}) produced an empty resource name.`,
+    );
+  }
 
   return verb + resource[0].toUpperCase() + resource.slice(1);
 }
@@ -99,7 +106,7 @@ export function normalizeSpec(inputPath, outputPath) {
 
   for (const [path, methods] of Object.entries(spec.paths ?? {})) {
     for (const [method, op] of Object.entries(methods)) {
-      if (typeof op !== "object" || !op.operationId) continue;
+      if (typeof op !== "object" || op === null || !op.operationId) continue;
       // Leave identifiers that have no spaces — they were set intentionally
       if (!/\s/.test(op.operationId)) continue;
       op.operationId = normalizeOperationId(method, path);

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -48,46 +48,34 @@ function normalizeOperationId(method, path) {
   const lastSeg = segments[segments.length - 1] ?? "";
   const isDetail = lastSeg.startsWith("{");
 
-  const verb =
-    method === "get"
-      ? isDetail
-        ? "get"
-        : "list"
-      : method === "post"
-        ? "create"
-        : method === "put" || method === "patch"
-          ? "update"
-          : method === "delete"
-            ? "delete"
-            : method;
+  const VERBS = { get: isDetail ? "get" : "list", post: "create", put: "update", patch: "update", delete: "delete" };
+  const verb = VERBS[method] ?? method;
 
   const parts = [];
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];
     if (seg.startsWith("{")) continue;
 
-    // Convert kebab-case to camelCase: events-timeseries → eventsTimeseries
+    // kebab-case → camelCase: events-timeseries → eventsTimeseries
     const camel = seg.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
 
-    // Singularize segments that scope a specific resource (immediately followed by a param)
-    const nextSeg = segments[i + 1] ?? "";
-    const followedByParam = nextSeg.startsWith("{");
+    // Segments immediately before a {param} scope a specific resource — singularize them.
+    const followedByParam = (segments[i + 1] ?? "").startsWith("{");
     parts.push(followedByParam ? singularize(camel) : camel);
   }
 
-  // Also singularize the last resource segment for detail GETs and creates
-  if ((isDetail || verb === "create") && parts.length > 0) {
-    parts[parts.length - 1] = singularize(parts[parts.length - 1]);
-  }
-
   if (parts.length === 0) {
-    // A path with no static segments (e.g. all {params}) cannot produce a
-    // meaningful name. This should not happen in a well-formed spec — if it
-    // does, the operationId should be set explicitly via @extend_schema.
+    // A path with no static segments cannot produce a meaningful name. Set
+    // operation_id explicitly via @extend_schema(operation_id=...) instead.
     throw new Error(
       `normalizeOperationId: no static segments in path "${path}" (${method.toUpperCase()}). ` +
         `Set operation_id explicitly via @extend_schema(operation_id=...).`,
     );
+  }
+
+  // Singularize the last segment for detail GETs and creates (you get/create one item).
+  if (isDetail || verb === "create") {
+    parts[parts.length - 1] = singularize(parts[parts.length - 1]);
   }
 
   const resource = parts

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -152,19 +152,20 @@ export function normalizeOperationId(method, path) {
   // Apply singularization in a single pass:
   //   - any segment immediately before a {param} scopes a specific resource
   //   - the final segment for detail GETs and creates (operating on one item)
-  const parts = statics.map((s, i) => {
-    const isLast = i === statics.length - 1;
-    const needsSingular = s.followedByParam || (isLast && (isDetail || verb === "create"));
-    return needsSingular ? s.singularValue : s.value;
-  });
+  const parts = statics
+    .map((s, i) => {
+      const isLast = i === statics.length - 1;
+      const needsSingular = s.followedByParam || (isLast && (isDetail || verb === "create"));
+      return needsSingular ? s.singularValue : s.value;
+    })
+    .filter(Boolean); // drop all-separator segments (e.g. "---") that camelCase to ""
 
-  const resource = parts
-    .map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1)))
-    .join("");
+  const resource = camelJoin(parts);
 
   // Guard the real invariant: the assembled resource must be non-empty. This
-  // covers both a path with no static segments and one whose only static
-  // segments are separators (e.g. "/---/"), which camelCase to "".
+  // covers a path with no static segments and one whose only static segments
+  // are separators (e.g. "/---/"); interior separator segments are dropped by
+  // the filter above so they can't crash the camelJoin assembly.
   if (resource.length === 0) {
     throw new Error(
       `normalizeOperationId: path "${path}" (${method.toUpperCase()}) has no ` +

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -16,6 +16,10 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 
+// ---------------------------------------------------------------------------
+// Singularization
+// ---------------------------------------------------------------------------
+
 const IRREGULAR = {
   activities: "activity",
   queries: "query",
@@ -26,11 +30,11 @@ const IRREGULAR = {
   analyses: "analysis",
 };
 
-function singularize(word) {
+export function singularize(word) {
   if (IRREGULAR[word]) return IRREGULAR[word];
   if (word.endsWith("ies")) return word.slice(0, -3) + "y";
-  // Regular -s removal: handles words like releases→release, teams→team, issues→issue.
-  // Avoid mutating words ending in -ss (class), -us (status), -is (analysis).
+  // Regular -s removal: releases→release, teams→team, issues→issue.
+  // Skip -ss (class), -us (status), -is (analysis) — these are already singular.
   if (
     word.endsWith("s") &&
     !word.endsWith("ss") &&
@@ -42,59 +46,97 @@ function singularize(word) {
   return word;
 }
 
-function normalizeOperationId(method, path) {
+// ---------------------------------------------------------------------------
+// Path parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses an API path into an array of segment descriptors.
+ *
+ * Each descriptor carries:
+ *   - `value`: the segment with kebab-case converted to camelCase
+ *   - `isParam`: true when the segment is a path parameter ({…})
+ *   - `followedByParam`: true when the next segment is a path parameter
+ *
+ * Empty segments (from leading/double slashes) are dropped upfront.
+ *
+ * @param {string} path - e.g. "/api/0/organizations/{org}/issues/{id}/"
+ * @returns {{ value: string; isParam: boolean; followedByParam: boolean }[]}
+ */
+export function parsePath(path) {
   const clean = path.replace(/^\/api\/0\//, "").replace(/\/$/, "");
-  const segments = clean.split("/");
-  const lastSeg = segments[segments.length - 1] ?? "";
-  const isDetail = lastSeg.startsWith("{");
+  const raw = clean.split("/").filter((s) => s.length > 0);
 
-  const VERBS = { get: isDetail ? "get" : "list", post: "create", put: "update", patch: "update", delete: "delete" };
-  const verb = VERBS[method] ?? method;
-
-  const parts = [];
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    if (seg.startsWith("{")) continue;
-
+  return raw.map((s, i) => ({
     // kebab-case → camelCase: events-timeseries → eventsTimeseries
-    const camel = seg.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
+    value: s.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
+    isParam: s.startsWith("{"),
+    followedByParam: raw[i + 1]?.startsWith("{") ?? false,
+  }));
+}
 
-    // Segments immediately before a {param} scope a specific resource — singularize them.
-    const followedByParam = (segments[i + 1] ?? "").startsWith("{");
-    parts.push(followedByParam ? singularize(camel) : camel);
-  }
+// ---------------------------------------------------------------------------
+// Name generation
+// ---------------------------------------------------------------------------
 
-  if (parts.length === 0) {
-    // A path with no static segments cannot produce a meaningful name. Set
-    // operation_id explicitly via @extend_schema(operation_id=...) instead.
+const VERBS = {
+  post: "create",
+  put: "update",
+  patch: "update",
+  delete: "delete",
+};
+
+/**
+ * Derives a short, REST-conventional camelCase identifier from an HTTP method
+ * and URL path.
+ *
+ * @param {string} method - HTTP method (lowercase: "get", "post", …)
+ * @param {string} path   - Full path, e.g. "/api/0/organizations/{org}/issues/{id}/"
+ * @returns {string} Normalized identifier, e.g. "getOrganizationIssue"
+ * @throws {Error} If the path has no static segments and cannot produce a name
+ */
+export function normalizeOperationId(method, path) {
+  const segments = parsePath(path);
+  const statics = segments.filter((s) => !s.isParam);
+
+  if (statics.length === 0) {
     throw new Error(
-      `normalizeOperationId: no static segments in path "${path}" (${method.toUpperCase()}). ` +
-        `Set operation_id explicitly via @extend_schema(operation_id=...).`,
+      `normalizeOperationId: no static segments in path "${path}" ` +
+        `(${method.toUpperCase()}). Set operation_id explicitly via ` +
+        `@extend_schema(operation_id=...).`,
     );
   }
 
-  // Singularize the last segment for detail GETs and creates (you get/create one item).
-  if (isDetail || verb === "create") {
-    parts[parts.length - 1] = singularize(parts[parts.length - 1]);
-  }
+  const isDetail = segments.at(-1)?.isParam ?? false;
+  const verb = method === "get" ? (isDetail ? "get" : "list") : (VERBS[method] ?? method);
+
+  // Apply singularization in a single pass:
+  //   - any segment immediately before a {param} scopes a specific resource
+  //   - the final segment for detail GETs and creates (operating on one item)
+  const parts = statics.map((s, i) => {
+    const isLast = i === statics.length - 1;
+    const needsSingular = s.followedByParam || (isLast && (isDetail || verb === "create"));
+    return needsSingular ? singularize(s.value) : s.value;
+  });
 
   const resource = parts
-    .filter((p) => p.length > 0) // drop empty strings from leading slashes on non-/api/0/ paths
     .map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1)))
     .join("");
-
-  if (resource.length === 0) {
-    throw new Error(
-      `normalizeOperationId: path "${path}" (${method.toUpperCase()}) produced an empty resource name.`,
-    );
-  }
 
   return verb + resource[0].toUpperCase() + resource.slice(1);
 }
 
+// ---------------------------------------------------------------------------
+// Spec rewriting
+// ---------------------------------------------------------------------------
+
 /**
  * Reads the spec at `inputPath`, rewrites all sentence-style operationIds to
  * short REST-conventional names, and writes the result to `outputPath`.
+ *
+ * Throws on name collisions — two operations normalizing to the same identifier
+ * would produce duplicate SDK exports, which must be resolved explicitly via
+ * @extend_schema(operation_id=...) on the backend endpoint.
  *
  * @param {string} inputPath  - Path to the source spec (e.g. openapi-derefed.json)
  * @param {string} outputPath - Path to write the normalized spec to
@@ -103,17 +145,27 @@ export function normalizeSpec(inputPath, outputPath) {
   // JSON.parse produces a fresh object every call; mutations are safe and
   // intentional — we rewrite operationIds in place before serialising.
   const spec = JSON.parse(readFileSync(inputPath, "utf8"));
+  const seen = new Map(); // normalized name → "METHOD /path" that first claimed it
 
   for (const [path, methods] of Object.entries(spec.paths ?? {})) {
     for (const [method, op] of Object.entries(methods)) {
       if (typeof op !== "object" || op === null || !op.operationId) continue;
-      // Leave identifiers that have no spaces — they were set intentionally
+      // Leave identifiers that have no spaces — set intentionally via @extend_schema
       if (!/\s/.test(op.operationId)) continue;
-      op.operationId = normalizeOperationId(method, path);
+
+      const normalized = normalizeOperationId(method, path);
+      const claimedBy = seen.get(normalized);
+      if (claimedBy) {
+        throw new Error(
+          `normalizeSpec: collision — "${normalized}" claimed by both ` +
+            `"${claimedBy}" and "${method.toUpperCase()} ${path}". ` +
+            `Set operation_id explicitly on one of them via @extend_schema(operation_id=...).`,
+        );
+      }
+      seen.set(normalized, `${method.toUpperCase()} ${path}`);
+      op.operationId = normalized;
     }
   }
 
   writeFileSync(outputPath, JSON.stringify(spec));
 }
-
-export { normalizeOperationId, singularize };

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -67,12 +67,16 @@ export function parsePath(path) {
   const clean = path.replace(/^\/api\/0\//, "").replace(/\/$/, "");
   const raw = clean.split("/").filter((s) => s.length > 0);
 
-  return raw.map((s, i) => ({
-    // kebab-case → camelCase: events-timeseries → eventsTimeseries
-    value: s.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
-    isParam: s.startsWith("{"),
-    followedByParam: raw[i + 1]?.startsWith("{") ?? false,
-  }));
+  return raw.map((s, i) => {
+    const isParam = s.startsWith("{");
+    return {
+      // kebab-case → camelCase only matters for static segments, but computing
+      // it unconditionally keeps the shape uniform and the cost is negligible.
+      value: isParam ? s : s.replace(/-([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
+      isParam,
+      followedByParam: raw[i + 1]?.startsWith("{") ?? false,
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -145,24 +149,41 @@ export function normalizeSpec(inputPath, outputPath) {
   // JSON.parse produces a fresh object every call; mutations are safe and
   // intentional — we rewrite operationIds in place before serialising.
   const spec = JSON.parse(readFileSync(inputPath, "utf8"));
-  const seen = new Map(); // normalized name → "METHOD /path" that first claimed it
+  // Track every final operationId (rewritten or pre-existing) so that a manually
+  // set clean identifier cannot collide with a path-derived one without detection.
+  const seen = new Map(); // final operationId → "METHOD /path" that first claimed it
 
   for (const [path, methods] of Object.entries(spec.paths ?? {})) {
     for (const [method, op] of Object.entries(methods)) {
       if (typeof op !== "object" || op === null || !op.operationId) continue;
-      // Leave identifiers that have no spaces — set intentionally via @extend_schema
-      if (!/\s/.test(op.operationId)) continue;
+
+      const ref = `${method.toUpperCase()} ${path}`;
+
+      if (!/\s/.test(op.operationId)) {
+        // Already a clean identifier — register it so sentence-style rewrites
+        // on other paths cannot silently collide with it.
+        const claimedBy = seen.get(op.operationId);
+        if (claimedBy) {
+          throw new Error(
+            `normalizeSpec: collision — "${op.operationId}" claimed by both ` +
+              `"${claimedBy}" and "${ref}". ` +
+              `Set operation_id explicitly on one of them via @extend_schema(operation_id=...).`,
+          );
+        }
+        seen.set(op.operationId, ref);
+        continue;
+      }
 
       const normalized = normalizeOperationId(method, path);
       const claimedBy = seen.get(normalized);
       if (claimedBy) {
         throw new Error(
           `normalizeSpec: collision — "${normalized}" claimed by both ` +
-            `"${claimedBy}" and "${method.toUpperCase()} ${path}". ` +
+            `"${claimedBy}" and "${ref}". ` +
             `Set operation_id explicitly on one of them via @extend_schema(operation_id=...).`,
         );
       }
-      seen.set(normalized, `${method.toUpperCase()} ${path}`);
+      seen.set(normalized, ref);
       op.operationId = normalized;
     }
   }

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -60,18 +60,39 @@ export function singularize(word) {
 // Path parsing
 // ---------------------------------------------------------------------------
 
+/** Hyphens and underscores → camelCase: events-timeseries → eventsTimeseries */
+function toCamel(s) {
+  return s.replace(/[-_]([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Singularizes the last word of a hyphen/underscore-separated segment, then
+ * converts the whole thing to camelCase.
+ *
+ * Singularizing the last word (not the full camelCase string) is critical for
+ * compound segments: "release-threshold-statuses" must become
+ * "releaseThresholdStatus", not "releaseThresholdStatuse". By splitting first,
+ * singularize() receives "statuses" and can match the IRREGULAR table.
+ */
+function toSingularCamel(s) {
+  const words = s.split(/[-_]/);
+  words[words.length - 1] = singularize(words[words.length - 1]);
+  return words.map((w, i) => (i === 0 ? w : w[0].toUpperCase() + w.slice(1))).join("");
+}
+
 /**
  * Parses an API path into an array of segment descriptors.
  *
  * Each descriptor carries:
- *   - `value`: the segment with kebab-case converted to camelCase
+ *   - `value`: the segment converted to camelCase (plural kept)
+ *   - `singularValue`: the segment with its last word singularized, then camelCased
  *   - `isParam`: true when the segment is a path parameter ({…})
  *   - `followedByParam`: true when the next segment is a path parameter
  *
  * Empty segments (from leading/double slashes) are dropped upfront.
  *
  * @param {string} path - e.g. "/api/0/organizations/{org}/issues/{id}/"
- * @returns {{ value: string; isParam: boolean; followedByParam: boolean }[]}
+ * @returns {{ value: string; singularValue: string; isParam: boolean; followedByParam: boolean }[]}
  */
 export function parsePath(path) {
   const clean = path.replace(/^\/api\/0\//, "").replace(/\/$/, "");
@@ -80,9 +101,8 @@ export function parsePath(path) {
   return raw.map((s, i) => {
     const isParam = s.startsWith("{");
     return {
-      // Hyphens and underscores are word separators for static segments (events-timeseries
-      // → eventsTimeseries, stats_v2 → statsV2). Params keep their raw form.
-      value: isParam ? s : s.replace(/[-_]([a-zA-Z0-9])/g, (_, c) => c.toUpperCase()),
+      value:         isParam ? s : toCamel(s),
+      singularValue: isParam ? s : toSingularCamel(s),
       isParam,
       followedByParam: raw[i + 1]?.startsWith("{") ?? false,
     };
@@ -130,7 +150,7 @@ export function normalizeOperationId(method, path) {
   const parts = statics.map((s, i) => {
     const isLast = i === statics.length - 1;
     const needsSingular = s.followedByParam || (isLast && (isDetail || verb === "create"));
-    return needsSingular ? singularize(s.value) : s.value;
+    return needsSingular ? s.singularValue : s.value;
   });
 
   const resource = parts

--- a/lib/normalize-spec.mjs
+++ b/lib/normalize-spec.mjs
@@ -43,6 +43,9 @@ const IRREGULAR = {
 export function singularize(word) {
   if (IRREGULAR[word]) return IRREGULAR[word];
   if (word.endsWith("ies")) return word.slice(0, -3) + "y";
+  // -shes → -sh, -ches → -ch, -xes → -x, -zes → -z, -ses → -se
+  if (/(?:sh|ch|x|z)es$/.test(word)) return word.slice(0, -2);
+  if (word.endsWith("ses") && !word.endsWith("sses")) return word.slice(0, -1);
   // Skip -ss (class), -us (status), -is (analysis) — already singular.
   if (
     word.endsWith("s") &&

--- a/scripts/generate-pagination.mjs
+++ b/scripts/generate-pagination.mjs
@@ -34,7 +34,8 @@ import { dirname, join, resolve } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
-const SPEC_PATH = join(ROOT, "openapi-derefed.json");
+// Use the normalized spec so cursor detection uses the same operationIds the SDK was built from.
+const SPEC_PATH = join(ROOT, "openapi-normalized.json");
 const SDK_PATH = join(ROOT, "src", "sdk.gen.ts");
 const TYPES_PATH = join(ROOT, "src", "types.gen.ts");
 const OUT_PATH = join(ROOT, "src", "pagination.gen.ts");

--- a/scripts/generate-pagination.mjs
+++ b/scripts/generate-pagination.mjs
@@ -27,15 +27,25 @@
  *   - src/pagination.gen.ts
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
-// Use the normalized spec so cursor detection uses the same operationIds the SDK was built from.
-const SPEC_PATH = join(ROOT, "openapi-normalized.json");
+// Prefer the normalized spec (written by build step 0.5) so cursor detection
+// uses the same operationIds the SDK was built from. Fall back to the source
+// spec if run in isolation (e.g. during development without a full build).
+const NORMALIZED_SPEC = join(ROOT, "openapi-normalized.json");
+const SOURCE_SPEC = join(ROOT, "openapi-derefed.json");
+const SPEC_PATH = existsSync(NORMALIZED_SPEC) ? NORMALIZED_SPEC : SOURCE_SPEC;
+if (SPEC_PATH === SOURCE_SPEC) {
+  process.stderr.write(
+    "[generate-pagination] openapi-normalized.json not found; " +
+      "falling back to openapi-derefed.json (run `bun run build` for normalized names)\n",
+  );
+}
 const SDK_PATH = join(ROOT, "src", "sdk.gen.ts");
 const TYPES_PATH = join(ROOT, "src", "types.gen.ts");
 const OUT_PATH = join(ROOT, "src", "pagination.gen.ts");

--- a/scripts/generate-pagination.mjs
+++ b/scripts/generate-pagination.mjs
@@ -133,8 +133,8 @@ for (const key of PAGINATED_BUT_UNMARKED) {
 
 /**
  * Parse `src/sdk.gen.ts` to extract, for each exported function:
- *   - fn:        function identifier (e.g. `listAnOrganization_sIssues`)
- *   - typeBase:  type name root (e.g. `ListAnOrganizationSissues`)
+ *   - fn:        function identifier (e.g. `listOrganizationIssues`)
+ *   - typeBase:  type name root (e.g. `ListOrganizationIssues`)
  *   - method:    HTTP method (`get`, `post`, ...)
  *   - url:       URL template
  *

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -5,7 +5,7 @@ import {
   parsePath,
   singularize,
 } from "../lib/normalize-spec.mjs";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -269,6 +269,26 @@ describe("normalizeSpec collision detection", () => {
     try { unlinkSync(output); } catch {}
   });
 
+  it("throws when a clean identifier collides with a path-derived one", () => {
+    // Pre-existing clean IDs must be tracked: if path A has operationId
+    // "listOrganizationIssues" (clean) and path B sentence-style normalizes to
+    // the same name, that's a collision even though B's ID was a sentence.
+    const input = writeSpec({
+      "/api/0/something/": {
+        // Manually set to the same name that the other path would generate.
+        get: { operationId: "listOrganizationIssues" },
+      },
+      "/api/0/organizations/{org}/issues/": {
+        // Sentence-style → normalizes to "listOrganizationIssues".
+        get: { operationId: "List An Organization's Issues" },
+      },
+    });
+    const output = join(tmpdir(), `out-${Date.now()}.json`);
+    expect(() => normalizeSpec(input, output)).toThrow(/collision/);
+    unlinkSync(input);
+    try { unlinkSync(output); } catch {}
+  });
+
   it("does not throw when operationIds are already clean identifiers", () => {
     const input = writeSpec({
       "/api/0/organizations/": {
@@ -290,7 +310,7 @@ describe("normalizeSpec collision detection", () => {
     });
     const output = join(tmpdir(), `out-${Date.now()}.json`);
     normalizeSpec(input, output);
-    const result = JSON.parse(require("node:fs").readFileSync(output, "utf8"));
+    const result = JSON.parse(readFileSync(output, "utf8"));
     expect(result.paths["/api/0/organizations/"].get.operationId).toBe(
       "listOrganizations",
     );

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -315,6 +315,17 @@ describe("normalizeOperationId", () => {
       /no .*usable static segments/,
     );
   });
+
+  it("skips interior all-separator segments instead of crashing", () => {
+    // An interior segment of pure separators camelCases to "". It must be
+    // dropped before assembly, not crash camelJoin on p[0].toUpperCase().
+    expect(normalizeOperationId("get", "/api/0/organizations/---/issues/")).toBe(
+      "listOrganizationsIssues",
+    );
+    expect(normalizeOperationId("get", "/api/0/orgs/___/issues/")).toBe(
+      "listOrgsIssues",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -108,6 +108,15 @@ describe("parsePath", () => {
     expect(statics.at(-1)?.value).toBe("releaseThresholdStatuses");
   });
 
+  it("handles consecutive separators without crashing", () => {
+    // "foo--bar" and "a__b" must not crash on the empty word between separators.
+    // Both value and singularValue go through the same split-filter-join path.
+    const segs = parsePath("/api/0/foo--bar/a__b/");
+    expect(segs[0]?.value).toBe("fooBar");
+    expect(segs[0]?.singularValue).toBe("fooBar");
+    expect(segs[1]?.value).toBe("aB");
+  });
+
   it("drops empty segments from leading slashes (non-/api/0/ paths)", () => {
     const segs = parsePath("/custom/resources/");
     expect(segs.every((s) => s.value.length > 0)).toBe(true);

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -54,6 +54,12 @@ describe("singularize", () => {
       expect(singularize(singularize(w))).toBe(singularize(w));
     }
   });
+
+  it("never returns an empty string", () => {
+    // Single-char input ending in s would produce "" without the stem guard.
+    expect(singularize("s")).toBe("s");
+    expect(singularize("")).toBe("");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -34,6 +34,15 @@ describe("singularize", () => {
     expect(singularize("checkins")).toBe("checkin");
   });
 
+  it("handles -shes, -ches, -xes, -zes plurals", () => {
+    expect(singularize("hashes")).toBe("hash");
+    expect(singularize("crashes")).toBe("crash");
+    expect(singularize("matches")).toBe("match");
+    expect(singularize("boxes")).toBe("box");
+    expect(singularize("indexes")).toBe("index");
+    expect(singularize("buzzes")).toBe("buzz");
+  });
+
   it("correctly singularizes releases (regression: -ses rule must not apply)", () => {
     expect(singularize("releases")).toBe("release");
   });

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -70,7 +70,7 @@ describe("parsePath", () => {
   it("strips /api/0/ prefix and trailing slash", () => {
     const segs = parsePath("/api/0/organizations/");
     expect(segs).toEqual([
-      { value: "organizations", isParam: false, followedByParam: false },
+      { value: "organizations", singularValue: "organization", isParam: false, followedByParam: false },
     ]);
   });
 
@@ -95,6 +95,17 @@ describe("parsePath", () => {
     const segs = parsePath("/api/0/organizations/{org}/stats_v2/");
     const statics = segs.filter((s) => !s.isParam);
     expect(statics.at(-1)?.value).toBe("statsV2");
+  });
+
+  it("singularValue singularizes the last word of a compound segment", () => {
+    const segs = parsePath(
+      "/api/0/organizations/{org}/release-threshold-statuses/{id}/",
+    );
+    const statics = segs.filter((s) => !s.isParam);
+    // "statuses" (last word) hits IRREGULAR → "status"; full camelCase result:
+    expect(statics.at(-1)?.singularValue).toBe("releaseThresholdStatus");
+    // value keeps the plural form
+    expect(statics.at(-1)?.value).toBe("releaseThresholdStatuses");
   });
 
   it("drops empty segments from leading slashes (non-/api/0/ paths)", () => {
@@ -204,6 +215,24 @@ describe("normalizeOperationId", () => {
     expect(normalizeOperationId("get", "/api/0/organizations/{org}/relay_usage/")).toBe(
       "listOrganizationRelayUsage",
     );
+  });
+
+  it("singularizes compound segments via last-word rule (regression)", () => {
+    // GET detail — last word "statuses" hits IRREGULAR → "status"
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{org}/release-threshold-statuses/{id}/",
+      ),
+    ).toBe("getOrganizationReleaseThresholdStatus"); // not "...Statuse"
+
+    // POST to collection — last word "issues" → "issue"
+    expect(
+      normalizeOperationId(
+        "post",
+        "/api/0/organizations/{org}/external-issues/",
+      ),
+    ).toBe("createOrganizationExternalIssue");
   });
 
   it("handles multi-level nesting", () => {

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -39,6 +39,18 @@ describe("singularize", () => {
     expect(singularize("event")).toBe("event");
     expect(singularize("monitor")).toBe("monitor");
   });
+
+  it("is idempotent — applying twice produces the same result", () => {
+    // Segments that get singularized in the loop AND again in the post-loop
+    // pass must not produce a garbled result. Since singularized words no
+    // longer end in 's', the second call is always a no-op.
+    const words = ["issues", "teams", "releases", "queries", "activities"];
+    for (const w of words) {
+      const once = singularize(w);
+      const twice = singularize(once);
+      expect(twice).toBe(once);
+    }
+  });
 });
 
 describe("normalizeOperationId", () => {
@@ -182,5 +194,53 @@ describe("normalizeOperationId", () => {
         "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/events/",
       ),
     ).toBe("listOrganizationIssueEvents");
+  });
+
+  // Edge cases
+  it("throws when path has no static segments at all", () => {
+    // All-param paths cannot produce a meaningful name; they should have
+    // an explicit operation_id set via @extend_schema instead.
+    expect(() => normalizeOperationId("get", "/api/0/{id}/")).toThrow(
+      /no static segments/,
+    );
+    expect(() => normalizeOperationId("get", "/api/0/{a}/{b}/")).toThrow(
+      /no static segments/,
+    );
+  });
+
+  it("handles paths not under /api/0/ prefix", () => {
+    // Paths without the standard prefix still work; static segments are used as-is
+    expect(normalizeOperationId("get", "/custom/resources/")).toBe(
+      "listCustomResources",
+    );
+  });
+
+  it("handles consecutive params (projects/{org}/{project}/)", () => {
+    // projects is singularized (followed by {org}), then {org} and {project} are skipped
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/",
+      ),
+    ).toBe("getProject");
+  });
+
+  it("already-clean identifiers are not passed through normalizeOperationId", () => {
+    // normalizeSpec skips these, but document that the function itself would
+    // still try to normalize if called directly — it treats the path, not the ID.
+    // The guard lives in normalizeSpec, not here.
+    expect(normalizeOperationId("get", "/api/0/organizations/")).toBe(
+      "listOrganizations",
+    );
+  });
+
+  it("handles path with trailing slash stripped correctly", () => {
+    // With and without trailing slash should produce the same result
+    expect(normalizeOperationId("get", "/api/0/organizations")).toBe(
+      "listOrganizations",
+    );
+    expect(normalizeOperationId("get", "/api/0/organizations/")).toBe(
+      "listOrganizations",
+    );
   });
 });

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -294,13 +294,25 @@ describe("normalizeOperationId", () => {
 
   it("throws when path has no static segments", () => {
     expect(() => normalizeOperationId("get", "/api/0/{id}/")).toThrow(
-      /no static segments/,
+      /no .*usable static segments/,
     );
   });
 
   it("throws on degenerate all-param path", () => {
     expect(() => normalizeOperationId("get", "/api/0/{a}/{b}/")).toThrow(
-      /no static segments/,
+      /no .*usable static segments/,
+    );
+  });
+
+  it("throws when the only static segment is separators (empty resource)", () => {
+    // splitWords("---") → [] → camelJoin → "", so statics.length is 1 but the
+    // assembled resource is empty. The guard must catch this, not crash on
+    // resource[0].toUpperCase().
+    expect(() => normalizeOperationId("get", "/api/0/---/")).toThrow(
+      /no .*usable static segments/,
+    );
+    expect(() => normalizeOperationId("get", "/api/0/___/")).toThrow(
+      /no .*usable static segments/,
     );
   });
 });

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -91,6 +91,12 @@ describe("parsePath", () => {
     expect(segs[0]?.value).toBe("fooBar");
   });
 
+  it("converts underscores to camelCase (e.g. stats_v2 → statsV2)", () => {
+    const segs = parsePath("/api/0/organizations/{org}/stats_v2/");
+    const statics = segs.filter((s) => !s.isParam);
+    expect(statics.at(-1)?.value).toBe("statsV2");
+  });
+
   it("drops empty segments from leading slashes (non-/api/0/ paths)", () => {
     const segs = parsePath("/custom/resources/");
     expect(segs.every((s) => s.value.length > 0)).toBe(true);
@@ -189,6 +195,15 @@ describe("normalizeOperationId", () => {
 
   it("handles uppercase letters after a hyphen", () => {
     expect(normalizeOperationId("get", "/api/0/foo-Bar/")).toBe("listFooBar");
+  });
+
+  it("converts underscores in path segments to camelCase", () => {
+    expect(normalizeOperationId("get", "/api/0/organizations/{org}/stats_v2/")).toBe(
+      "listOrganizationStatsV2",
+    );
+    expect(normalizeOperationId("get", "/api/0/organizations/{org}/relay_usage/")).toBe(
+      "listOrganizationRelayUsage",
+    );
   });
 
   it("handles multi-level nesting", () => {

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -242,4 +242,18 @@ describe("normalizeOperationId", () => {
       "listOrganizations",
     );
   });
+
+  it("converts uppercase letters after a hyphen (Bug: regex was [a-z0-9] only)", () => {
+    // Hypothetical segment foo-Bar — B must be uppercased and hyphen removed.
+    // Real Sentry paths are lowercase, but the regex should be correct regardless.
+    expect(normalizeOperationId("get", "/api/0/foo-Bar/")).toBe("listFooBar");
+  });
+
+  it("throws when all static segments are empty strings (degenerate path)", () => {
+    // A path like // produces empty-string segments. Even if parts.length > 0,
+    // an all-empty resource name must not silently produce 'listUndefined'.
+    expect(() => normalizeOperationId("get", "//")).toThrow(
+      /empty resource name/,
+    );
+  });
 });

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "bun:test";
+import {
+  normalizeOperationId,
+  singularize,
+} from "../lib/normalize-spec.mjs";
+
+describe("singularize", () => {
+  it("removes trailing s for regular plurals", () => {
+    expect(singularize("issues")).toBe("issue");
+    expect(singularize("dashboards")).toBe("dashboard");
+    expect(singularize("teams")).toBe("team");
+    expect(singularize("projects")).toBe("project");
+    expect(singularize("replays")).toBe("replay");
+  });
+
+  it("handles -ies plurals", () => {
+    expect(singularize("activities")).toBe("activity");
+    expect(singularize("queries")).toBe("query");
+    expect(singularize("entries")).toBe("entry");
+  });
+
+  it("uses the irregular lookup table", () => {
+    expect(singularize("aliases")).toBe("alias");
+    expect(singularize("statuses")).toBe("status");
+    expect(singularize("checkins")).toBe("checkin");
+  });
+
+  it("correctly singularizes releases (regression: ses rule must not apply)", () => {
+    expect(singularize("releases")).toBe("release");
+  });
+
+  it("leaves words ending in -ss, -us, -is untouched", () => {
+    expect(singularize("class")).toBe("class");
+    expect(singularize("status")).toBe("status"); // in irregular, but also ends in -us
+    expect(singularize("analysis")).toBe("analysis");
+  });
+
+  it("leaves already-singular words untouched", () => {
+    expect(singularize("event")).toBe("event");
+    expect(singularize("monitor")).toBe("monitor");
+  });
+});
+
+describe("normalizeOperationId", () => {
+  // Collection GETs → list + plural
+  it("GET collection → list", () => {
+    expect(normalizeOperationId("get", "/api/0/organizations/")).toBe(
+      "listOrganizations",
+    );
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/issues/",
+      ),
+    ).toBe("listOrganizationIssues");
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/events/",
+      ),
+    ).toBe("listOrganizationIssueEvents");
+  });
+
+  // Detail GETs → get + singular
+  it("GET detail (ends in param) → get + singularized", () => {
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/",
+      ),
+    ).toBe("getOrganization");
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/",
+      ),
+    ).toBe("getOrganizationIssue");
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/dashboards/{dashboard_id}/",
+      ),
+    ).toBe("getOrganizationDashboard");
+  });
+
+  // POST → create + singular
+  it("POST → create + singularized last segment", () => {
+    expect(
+      normalizeOperationId(
+        "post",
+        "/api/0/organizations/{organization_id_or_slug}/dashboards/",
+      ),
+    ).toBe("createOrganizationDashboard");
+    expect(
+      normalizeOperationId(
+        "post",
+        "/api/0/organizations/{organization_id_or_slug}/teams/",
+      ),
+    ).toBe("createOrganizationTeam");
+  });
+
+  // PUT/PATCH → update
+  it("PUT/PATCH → update", () => {
+    expect(
+      normalizeOperationId(
+        "put",
+        "/api/0/organizations/{organization_id_or_slug}/dashboards/{dashboard_id}/",
+      ),
+    ).toBe("updateOrganizationDashboard");
+    expect(
+      normalizeOperationId(
+        "patch",
+        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/",
+      ),
+    ).toBe("updateOrganizationIssue");
+  });
+
+  // DELETE detail → singular; DELETE collection → plural
+  it("DELETE detail → singular", () => {
+    expect(
+      normalizeOperationId(
+        "delete",
+        "/api/0/organizations/{organization_id_or_slug}/dashboards/{dashboard_id}/",
+      ),
+    ).toBe("deleteOrganizationDashboard");
+  });
+
+  it("DELETE collection (bulk) → plural", () => {
+    expect(
+      normalizeOperationId(
+        "delete",
+        "/api/0/organizations/{organization_id_or_slug}/detectors/",
+      ),
+    ).toBe("deleteOrganizationDetectors");
+  });
+
+  // Hyphenated path segments → camelCase
+  it("converts kebab-case path segments to camelCase", () => {
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/events-timeseries/",
+      ),
+    ).toBe("listOrganizationEventsTimeseries");
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/release-threshold-statuses/",
+      ),
+    ).toBe("listOrganizationReleaseThresholdStatuses");
+  });
+
+  // Nested paths
+  it("handles multi-level nesting correctly", () => {
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/keys/",
+      ),
+    ).toBe("listProjectKeys");
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/keys/{key_id}/",
+      ),
+    ).toBe("getProjectKey");
+  });
+
+  // Parents singularized when followed by a param
+  it("singularizes parent segments that precede a path param", () => {
+    // organizations/{org}/ → organization (not organizations)
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/issues/",
+      ),
+    ).toBe("listOrganizationIssues");
+    // issues/{id}/events/ → issue (not issues) in the resource name
+    expect(
+      normalizeOperationId(
+        "get",
+        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/events/",
+      ),
+    ).toBe("listOrganizationIssueEvents");
+  });
+});

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -225,10 +225,9 @@ describe("normalizeOperationId", () => {
     ).toBe("getProject");
   });
 
-  it("already-clean identifiers are not passed through normalizeOperationId", () => {
-    // normalizeSpec skips these, but document that the function itself would
-    // still try to normalize if called directly — it treats the path, not the ID.
-    // The guard lives in normalizeSpec, not here.
+  it("normalizes the path regardless of what the original operationId was", () => {
+    // normalizeOperationId derives a name purely from method + path.
+    // The guard that skips already-clean identifiers lives in normalizeSpec.
     expect(normalizeOperationId("get", "/api/0/organizations/")).toBe(
       "listOrganizations",
     );

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "bun:test";
 import {
   normalizeOperationId,
+  normalizeSpec,
+  parsePath,
   singularize,
 } from "../lib/normalize-spec.mjs";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// singularize
+// ---------------------------------------------------------------------------
 
 describe("singularize", () => {
   it("removes trailing s for regular plurals", () => {
@@ -25,13 +34,13 @@ describe("singularize", () => {
     expect(singularize("checkins")).toBe("checkin");
   });
 
-  it("correctly singularizes releases (regression: ses rule must not apply)", () => {
+  it("correctly singularizes releases (regression: -ses rule must not apply)", () => {
     expect(singularize("releases")).toBe("release");
   });
 
   it("leaves words ending in -ss, -us, -is untouched", () => {
     expect(singularize("class")).toBe("class");
-    expect(singularize("status")).toBe("status"); // in irregular, but also ends in -us
+    expect(singularize("status")).toBe("status");
     expect(singularize("analysis")).toBe("analysis");
   });
 
@@ -41,200 +50,181 @@ describe("singularize", () => {
   });
 
   it("is idempotent — applying twice produces the same result", () => {
-    // Segments that get singularized in the loop AND again in the post-loop
-    // pass must not produce a garbled result. Since singularized words no
-    // longer end in 's', the second call is always a no-op.
-    const words = ["issues", "teams", "releases", "queries", "activities"];
-    for (const w of words) {
-      const once = singularize(w);
-      const twice = singularize(once);
-      expect(twice).toBe(once);
+    for (const w of ["issues", "teams", "releases", "queries", "activities"]) {
+      expect(singularize(singularize(w))).toBe(singularize(w));
     }
   });
 });
 
+// ---------------------------------------------------------------------------
+// parsePath
+// ---------------------------------------------------------------------------
+
+describe("parsePath", () => {
+  it("strips /api/0/ prefix and trailing slash", () => {
+    const segs = parsePath("/api/0/organizations/");
+    expect(segs).toEqual([
+      { value: "organizations", isParam: false, followedByParam: false },
+    ]);
+  });
+
+  it("marks path params correctly", () => {
+    const segs = parsePath("/api/0/organizations/{org}/issues/{id}/");
+    expect(segs.map((s) => s.isParam)).toEqual([false, true, false, true]);
+    expect(segs.map((s) => s.followedByParam)).toEqual([true, false, true, false]);
+  });
+
+  it("converts kebab-case to camelCase", () => {
+    const segs = parsePath("/api/0/organizations/{org}/events-timeseries/");
+    const values = segs.filter((s) => !s.isParam).map((s) => s.value);
+    expect(values).toEqual(["organizations", "eventsTimeseries"]);
+  });
+
+  it("handles uppercase letters after a hyphen", () => {
+    const segs = parsePath("/api/0/foo-Bar/");
+    expect(segs[0]?.value).toBe("fooBar");
+  });
+
+  it("drops empty segments from leading slashes (non-/api/0/ paths)", () => {
+    const segs = parsePath("/custom/resources/");
+    expect(segs.every((s) => s.value.length > 0)).toBe(true);
+    expect(segs.map((s) => s.value)).toEqual(["custom", "resources"]);
+  });
+
+  it("returns empty array for a path of only params", () => {
+    // parsePath itself never throws — normalizeOperationId validates the result
+    const segs = parsePath("/api/0/{a}/{b}/");
+    expect(segs.every((s) => s.isParam)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeOperationId
+// ---------------------------------------------------------------------------
+
 describe("normalizeOperationId", () => {
-  // Collection GETs → list + plural
   it("GET collection → list", () => {
     expect(normalizeOperationId("get", "/api/0/organizations/")).toBe(
       "listOrganizations",
     );
     expect(
-      normalizeOperationId(
-        "get",
-        "/api/0/organizations/{organization_id_or_slug}/issues/",
-      ),
+      normalizeOperationId("get", "/api/0/organizations/{org}/issues/"),
     ).toBe("listOrganizationIssues");
     expect(
       normalizeOperationId(
         "get",
-        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/events/",
+        "/api/0/organizations/{org}/issues/{id}/events/",
       ),
     ).toBe("listOrganizationIssueEvents");
   });
 
-  // Detail GETs → get + singular
   it("GET detail (ends in param) → get + singularized", () => {
     expect(
-      normalizeOperationId(
-        "get",
-        "/api/0/organizations/{organization_id_or_slug}/",
-      ),
+      normalizeOperationId("get", "/api/0/organizations/{org}/"),
     ).toBe("getOrganization");
     expect(
-      normalizeOperationId(
-        "get",
-        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/",
-      ),
+      normalizeOperationId("get", "/api/0/organizations/{org}/issues/{id}/"),
     ).toBe("getOrganizationIssue");
     expect(
       normalizeOperationId(
         "get",
-        "/api/0/organizations/{organization_id_or_slug}/dashboards/{dashboard_id}/",
+        "/api/0/organizations/{org}/dashboards/{id}/",
       ),
     ).toBe("getOrganizationDashboard");
   });
 
-  // POST → create + singular
   it("POST → create + singularized last segment", () => {
     expect(
-      normalizeOperationId(
-        "post",
-        "/api/0/organizations/{organization_id_or_slug}/dashboards/",
-      ),
+      normalizeOperationId("post", "/api/0/organizations/{org}/dashboards/"),
     ).toBe("createOrganizationDashboard");
     expect(
-      normalizeOperationId(
-        "post",
-        "/api/0/organizations/{organization_id_or_slug}/teams/",
-      ),
+      normalizeOperationId("post", "/api/0/organizations/{org}/teams/"),
     ).toBe("createOrganizationTeam");
   });
 
-  // PUT/PATCH → update
   it("PUT/PATCH → update", () => {
     expect(
-      normalizeOperationId(
-        "put",
-        "/api/0/organizations/{organization_id_or_slug}/dashboards/{dashboard_id}/",
-      ),
+      normalizeOperationId("put", "/api/0/organizations/{org}/dashboards/{id}/"),
     ).toBe("updateOrganizationDashboard");
     expect(
-      normalizeOperationId(
-        "patch",
-        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/",
-      ),
+      normalizeOperationId("patch", "/api/0/organizations/{org}/issues/{id}/"),
     ).toBe("updateOrganizationIssue");
   });
 
-  // DELETE detail → singular; DELETE collection → plural
   it("DELETE detail → singular", () => {
     expect(
       normalizeOperationId(
         "delete",
-        "/api/0/organizations/{organization_id_or_slug}/dashboards/{dashboard_id}/",
+        "/api/0/organizations/{org}/dashboards/{id}/",
       ),
     ).toBe("deleteOrganizationDashboard");
   });
 
   it("DELETE collection (bulk) → plural", () => {
     expect(
-      normalizeOperationId(
-        "delete",
-        "/api/0/organizations/{organization_id_or_slug}/detectors/",
-      ),
+      normalizeOperationId("delete", "/api/0/organizations/{org}/detectors/"),
     ).toBe("deleteOrganizationDetectors");
   });
 
-  // Hyphenated path segments → camelCase
   it("converts kebab-case path segments to camelCase", () => {
     expect(
       normalizeOperationId(
         "get",
-        "/api/0/organizations/{organization_id_or_slug}/events-timeseries/",
+        "/api/0/organizations/{org}/events-timeseries/",
       ),
     ).toBe("listOrganizationEventsTimeseries");
     expect(
       normalizeOperationId(
         "get",
-        "/api/0/organizations/{organization_id_or_slug}/release-threshold-statuses/",
+        "/api/0/organizations/{org}/release-threshold-statuses/",
       ),
     ).toBe("listOrganizationReleaseThresholdStatuses");
   });
 
-  // Nested paths
-  it("handles multi-level nesting correctly", () => {
+  it("handles uppercase letters after a hyphen", () => {
+    expect(normalizeOperationId("get", "/api/0/foo-Bar/")).toBe("listFooBar");
+  });
+
+  it("handles multi-level nesting", () => {
     expect(
       normalizeOperationId(
         "get",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/keys/",
+        "/api/0/projects/{org}/{project}/keys/",
       ),
     ).toBe("listProjectKeys");
     expect(
       normalizeOperationId(
         "get",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/keys/{key_id}/",
+        "/api/0/projects/{org}/{project}/keys/{id}/",
       ),
     ).toBe("getProjectKey");
   });
 
-  // Parents singularized when followed by a param
   it("singularizes parent segments that precede a path param", () => {
-    // organizations/{org}/ → organization (not organizations)
     expect(
-      normalizeOperationId(
-        "get",
-        "/api/0/organizations/{organization_id_or_slug}/issues/",
-      ),
+      normalizeOperationId("get", "/api/0/organizations/{org}/issues/"),
     ).toBe("listOrganizationIssues");
-    // issues/{id}/events/ → issue (not issues) in the resource name
     expect(
       normalizeOperationId(
         "get",
-        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/events/",
+        "/api/0/organizations/{org}/issues/{id}/events/",
       ),
     ).toBe("listOrganizationIssueEvents");
   });
 
-  // Edge cases
-  it("throws when path has no static segments at all", () => {
-    // All-param paths cannot produce a meaningful name; they should have
-    // an explicit operation_id set via @extend_schema instead.
-    expect(() => normalizeOperationId("get", "/api/0/{id}/")).toThrow(
-      /no static segments/,
-    );
-    expect(() => normalizeOperationId("get", "/api/0/{a}/{b}/")).toThrow(
-      /no static segments/,
-    );
+  it("handles consecutive params (/projects/{org}/{project}/)", () => {
+    expect(
+      normalizeOperationId("get", "/api/0/projects/{org}/{project}/"),
+    ).toBe("getProject");
   });
 
   it("handles paths not under /api/0/ prefix", () => {
-    // Paths without the standard prefix still work; static segments are used as-is
     expect(normalizeOperationId("get", "/custom/resources/")).toBe(
       "listCustomResources",
     );
   });
 
-  it("handles consecutive params (projects/{org}/{project}/)", () => {
-    // projects is singularized (followed by {org}), then {org} and {project} are skipped
-    expect(
-      normalizeOperationId(
-        "get",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/",
-      ),
-    ).toBe("getProject");
-  });
-
-  it("normalizes the path regardless of what the original operationId was", () => {
-    // normalizeOperationId derives a name purely from method + path.
-    // The guard that skips already-clean identifiers lives in normalizeSpec.
-    expect(normalizeOperationId("get", "/api/0/organizations/")).toBe(
-      "listOrganizations",
-    );
-  });
-
-  it("handles path with trailing slash stripped correctly", () => {
-    // With and without trailing slash should produce the same result
+  it("trailing slash presence does not affect the result", () => {
     expect(normalizeOperationId("get", "/api/0/organizations")).toBe(
       "listOrganizations",
     );
@@ -243,17 +233,71 @@ describe("normalizeOperationId", () => {
     );
   });
 
-  it("converts uppercase letters after a hyphen (Bug: regex was [a-z0-9] only)", () => {
-    // Hypothetical segment foo-Bar — B must be uppercased and hyphen removed.
-    // Real Sentry paths are lowercase, but the regex should be correct regardless.
-    expect(normalizeOperationId("get", "/api/0/foo-Bar/")).toBe("listFooBar");
+  it("throws when path has no static segments", () => {
+    expect(() => normalizeOperationId("get", "/api/0/{id}/")).toThrow(
+      /no static segments/,
+    );
   });
 
-  it("throws when all static segments are empty strings (degenerate path)", () => {
-    // A path like // produces empty-string segments. Even if parts.length > 0,
-    // an all-empty resource name must not silently produce 'listUndefined'.
-    expect(() => normalizeOperationId("get", "//")).toThrow(
-      /empty resource name/,
+  it("throws on degenerate all-param path", () => {
+    expect(() => normalizeOperationId("get", "/api/0/{a}/{b}/")).toThrow(
+      /no static segments/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSpec — collision detection
+// ---------------------------------------------------------------------------
+
+describe("normalizeSpec collision detection", () => {
+  function writeSpec(paths: Record<string, Record<string, unknown>>) {
+    const tmp = join(tmpdir(), `test-spec-${Date.now()}.json`);
+    writeFileSync(tmp, JSON.stringify({ paths }));
+    return tmp;
+  }
+
+  it("throws when two different paths normalize to the same name", () => {
+    // /api/0/x-y/ and /api/0/xY/ both produce "listXY" after kebab→camelCase.
+    const input = writeSpec({
+      "/api/0/x-y/": { get: { operationId: "List X Y" } },
+      "/api/0/xY/": { get: { operationId: "List XY" } },
+    });
+    const output = join(tmpdir(), `out-${Date.now()}.json`);
+    expect(() => normalizeSpec(input, output)).toThrow(/collision/);
+    unlinkSync(input);
+    try { unlinkSync(output); } catch {}
+  });
+
+  it("does not throw when operationIds are already clean identifiers", () => {
+    const input = writeSpec({
+      "/api/0/organizations/": {
+        get: { operationId: "listOrganizations" }, // already clean — skipped
+      },
+    });
+    const output = join(tmpdir(), `out-${Date.now()}.json`);
+    expect(() => normalizeSpec(input, output)).not.toThrow();
+    unlinkSync(input);
+    try { unlinkSync(output); } catch {}
+  });
+
+  it("rewrites sentence-style operationIds and leaves clean ones alone", () => {
+    const input = writeSpec({
+      "/api/0/organizations/": {
+        get: { operationId: "List Your Organizations" },
+        post: { operationId: "createOrganization" }, // already clean
+      },
+    });
+    const output = join(tmpdir(), `out-${Date.now()}.json`);
+    normalizeSpec(input, output);
+    const result = JSON.parse(require("node:fs").readFileSync(output, "utf8"));
+    expect(result.paths["/api/0/organizations/"].get.operationId).toBe(
+      "listOrganizations",
+    );
+    expect(result.paths["/api/0/organizations/"].post.operationId).toBe(
+      "createOrganization", // untouched
+    );
+    unlinkSync(input);
+    unlinkSync(output);
   });
 });

--- a/test/normalize-spec.test.ts
+++ b/test/normalize-spec.test.ts
@@ -43,14 +43,22 @@ describe("singularize", () => {
     expect(singularize("buzzes")).toBe("buzz");
   });
 
+  it("handles -sses plurals (classes → class)", () => {
+    expect(singularize("classes")).toBe("class");
+    expect(singularize("processes")).toBe("process");
+    expect(singularize("addresses")).toBe("address");
+  });
+
   it("correctly singularizes releases (regression: -ses rule must not apply)", () => {
     expect(singularize("releases")).toBe("release");
   });
 
-  it("leaves words ending in -ss, -us, -is untouched", () => {
+  it("leaves words ending in -ss, -us, -is, -as untouched", () => {
     expect(singularize("class")).toBe("class");
     expect(singularize("status")).toBe("status");
     expect(singularize("analysis")).toBe("analysis");
+    expect(singularize("alias")).toBe("alias");
+    expect(singularize("atlas")).toBe("atlas");
   });
 
   it("leaves already-singular words untouched", () => {
@@ -59,7 +67,10 @@ describe("singularize", () => {
   });
 
   it("is idempotent — applying twice produces the same result", () => {
-    for (const w of ["issues", "teams", "releases", "queries", "activities"]) {
+    for (const w of [
+      "issues", "teams", "releases", "queries", "activities",
+      "aliases", "hashes", "classes", "boxes", "processes",
+    ]) {
       expect(singularize(singularize(w))).toBe(singularize(w));
     }
   });

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -13,12 +13,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   fetchPage,
-  fetchPage_listAnOrganization_sIssues,
-  fetchPage_listYourOrganizations,
+  fetchPage_listOrganizationIssues,
+  fetchPage_listOrganizations,
   paginateAll,
-  paginateAll_listYourOrganizations,
+  paginateAll_listOrganizations,
   paginateUpTo,
-  paginateUpTo_listYourOrganizations,
+  paginateUpTo_listOrganizations,
   parseSentryLinkHeader,
   unwrapPaginatedResult,
   unwrapResult,
@@ -375,30 +375,30 @@ describe("paginateUpTo", () => {
 // =====================================================================
 
 describe("generated wrappers (pagination.gen.ts)", () => {
-  test("fetchPage_listYourOrganizations is callable with no args", () => {
+  test("fetchPage_listOrganizations is callable with no args", () => {
     // We don't actually invoke (would need network); we assert it exists,
     // is a function, and has the expected arity (options + cursor = 2 named
     // params, but JS reports the count up to the first default — so 1).
-    expect(typeof fetchPage_listYourOrganizations).toBe("function");
+    expect(typeof fetchPage_listOrganizations).toBe("function");
   });
 
   test("paginateAll_/paginateUpTo_ wrappers exist for array-shaped ops", () => {
-    expect(typeof paginateAll_listYourOrganizations).toBe("function");
-    expect(typeof paginateUpTo_listYourOrganizations).toBe("function");
+    expect(typeof paginateAll_listOrganizations).toBe("function");
+    expect(typeof paginateUpTo_listOrganizations).toBe("function");
   });
 
   test("only fetchPage_ is generated for compound-shaped ops", () => {
     // listAnOrganization_sIssues is array-shaped, so all three exist.
-    expect(typeof fetchPage_listAnOrganization_sIssues).toBe("function");
+    expect(typeof fetchPage_listOrganizationIssues).toBe("function");
     // For a compound op like listClickedNodes (200: { ... } not Array<>),
     // paginateAll/paginateUpTo are intentionally not generated — items
     // can't be flattened across pages without knowing which field holds
     // the array, and that's spec-specific.
     const indexModule = require("../src/index") as Record<string, unknown>;
     const keys = Object.keys(indexModule);
-    expect(keys).toContain("fetchPage_listClickedNodes");
-    expect(keys).not.toContain("paginateAll_listClickedNodes");
-    expect(keys).not.toContain("paginateUpTo_listClickedNodes");
+    expect(keys).toContain("fetchPage_listProjectReplayClicks");
+    expect(keys).not.toContain("paginateAll_listProjectReplayClicks");
+    expect(keys).not.toContain("paginateUpTo_listProjectReplayClicks");
   });
 
 });

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -388,9 +388,9 @@ describe("generated wrappers (pagination.gen.ts)", () => {
   });
 
   test("only fetchPage_ is generated for compound-shaped ops", () => {
-    // listAnOrganization_sIssues is array-shaped, so all three exist.
+    // listOrganizationIssues is array-shaped, so all three exist.
     expect(typeof fetchPage_listOrganizationIssues).toBe("function");
-    // For a compound op like listClickedNodes (200: { ... } not Array<>),
+    // For a compound op like listProjectReplayClicks (200: { ... } not Array<>),
     // paginateAll/paginateUpTo are intentionally not generated — items
     // can't be flattened across pages without knowing which field holds
     // the array, and that's spec-specific.

--- a/test/typecheck.ts
+++ b/test/typecheck.ts
@@ -12,12 +12,12 @@
  */
 
 import {
-  fetchPage_listAnOrganization_sIssues,
-  fetchPage_listAnOrganization_sProjects,
-  fetchPage_listClickedNodes,
-  paginateAll_listAnOrganization_sIssues,
-  paginateAll_listAnOrganization_sProjects,
-  paginateUpTo_listAnOrganization_sIssues,
+  fetchPage_listOrganizationIssues,
+  fetchPage_listOrganizationProjects,
+  fetchPage_listProjectReplayClicks,
+  paginateAll_listOrganizationIssues,
+  paginateAll_listOrganizationProjects,
+  paginateUpTo_listOrganizationIssues,
 } from "../src/index";
 
 const config = {
@@ -30,7 +30,7 @@ const config = {
 // =====================================================================
 
 async function fetchPageHappyPath() {
-  const result = await fetchPage_listAnOrganization_sIssues({
+  const result = await fetchPage_listOrganizationIssues({
     ...config,
     path: { organization_id_or_slug: "my-org" },
     query: {
@@ -49,7 +49,7 @@ async function fetchPageHappyPath() {
 }
 
 async function fetchPageRejectsCursor() {
-  await fetchPage_listAnOrganization_sIssues({
+  await fetchPage_listOrganizationIssues({
     ...config,
     path: { organization_id_or_slug: "my-org" },
     query: {
@@ -61,7 +61,7 @@ async function fetchPageRejectsCursor() {
 
 async function fetchPageRequiresPath() {
   // @ts-expect-error — required path param must still be required
-  await fetchPage_listAnOrganization_sIssues({
+  await fetchPage_listOrganizationIssues({
     ...config,
     query: { limit: 25 },
   });
@@ -72,7 +72,7 @@ async function fetchPageRequiresPath() {
 // =====================================================================
 
 async function paginateAllHappyPath() {
-  const items = await paginateAll_listAnOrganization_sIssues({
+  const items = await paginateAll_listOrganizationIssues({
     ...config,
     path: { organization_id_or_slug: "my-org" },
     query: { limit: 100 },
@@ -82,7 +82,7 @@ async function paginateAllHappyPath() {
 }
 
 async function paginateUpToHappyPath() {
-  const result = await paginateUpTo_listAnOrganization_sIssues(
+  const result = await paginateUpTo_listOrganizationIssues(
     {
       ...config,
       path: { organization_id_or_slug: "my-org" },
@@ -101,7 +101,7 @@ async function paginateUpToHappyPath() {
 // =====================================================================
 
 async function fetchPageCompoundOp() {
-  const result = await fetchPage_listClickedNodes({
+  const result = await fetchPage_listProjectReplayClicks({
     ...config,
     path: {
       organization_id_or_slug: "my-org",
@@ -122,7 +122,7 @@ async function perPageAcceptedEvenWhenSpecOmitsIt() {
   // /organizations/{org}/projects/ has only `cursor` declared in the spec,
   // but the runtime accepts `per_page`. PaginationQuery widens with it so
   // callers don't need an `as` cast.
-  await paginateAll_listAnOrganization_sProjects({
+  await paginateAll_listOrganizationProjects({
     ...config,
     path: { organization_id_or_slug: "my-org" },
     query: { per_page: 100 },
@@ -130,7 +130,7 @@ async function perPageAcceptedEvenWhenSpecOmitsIt() {
 
   // Same for fetchPage on issues — per_page co-exists with documented
   // params (collapse, limit, sort, etc.).
-  await fetchPage_listAnOrganization_sProjects({
+  await fetchPage_listOrganizationProjects({
     ...config,
     path: { organization_id_or_slug: "my-org" },
     query: { per_page: 100 },
@@ -145,7 +145,7 @@ async function paginateUpToKeepCursorOnOvershoot() {
   // For /issues/{id}/events/ (and any endpoint with no server-side
   // per_page), passing keepCursorOnOvershoot:true preserves access to
   // trimmed-tail items via the same cursor on the next call.
-  const result = await paginateUpTo_listAnOrganization_sIssues(
+  const result = await paginateUpTo_listOrganizationIssues(
     {
       ...config,
       path: { organization_id_or_slug: "my-org" },


### PR DESCRIPTION
The generated SDK function names are currently verbose camelCase of English sentences — `listYourOrganizations`, `retrieveAnOrganization_sCustomDashboard`, `listAnOrganization_sIssues`. These are unusable as a public API surface for the planned TanStack Query factories and the eventual frontend migration.

This adds a normalization step (`lib/normalize-spec.mjs`) that runs in `build.mjs` before the code generator, rewriting sentence-style operationIds to short, REST-conventional names derived from the HTTP method and URL path:

```
operation                                  current name                          → new name
GET    /organizations/{org}/issues/        listAnOrganization_sIssues            → listOrganizationIssues
GET    /organizations/{org}/issues/{id}/   retrieveAnIssue                       → getOrganizationIssue
POST   /organizations/{org}/dashboards/    createANewDashboardForAnOrganization  → createOrganizationDashboard
DELETE /organizations/{org}/detectors/     bulkDeleteMonitors                    → deleteOrganizationDetectors  (bulk)
```

The gains are largest for the worst current offenders:

```
operation                                          current name                                               → new name
GET /organizations/{org}/sentry-app-installations/ listAnOrganization_sIntegrationPlatformInstallations       → listOrganizationSentryAppInstallations
GET /organizations/{org}/replay-count/             retrieveACountOfReplaysForAGivenIssueOrTransaction         → listOrganizationReplayCount
GET /organizations/{org}/issues/{id}/external-...  retrieveCustomIntegrationIssueLinksForTheGivenSentryIssue  → listOrganizationIssueExternalIssues
GET /projects/{org}/{proj}/events/{id}/source-...  getDebugInformationRelatedToSourceMapsForAGivenEvent       → listProjectEventSourceMapDebug
```

Rules: collection GETs → `list`, detail GETs (path ends in `{param}`) → `get`, POST → `create`, PUT/PATCH → `update`, DELETE → `delete`/`delete` (detail vs bulk). Parent segments before a `{param}` are singularized. Kebab-case and snake_case segments are converted to camelCase. Any operationId already an identifier (no spaces) is left untouched — those were set intentionally via `@extend_schema(operation_id=...)`.

Validated against the full Sentry spec: **216 sentence-style operationIds, 0 collisions, 0 underscores in output names**.

### What changed

- **`lib/normalize-spec.mjs`**: new hand-written module with three exported functions — `parsePath` (path → typed segment descriptors), `normalizeOperationId` (method + path → identifier), `normalizeSpec` (rewrites the spec file in place, throws on collisions)
- **`build.mjs`**: step 0.5 normalizes `openapi-derefed.json` → `openapi-normalized.json` before `createClient()` runs; source spec is never modified
- **`scripts/generate-pagination.mjs`**: reads `openapi-normalized.json` (falls back to `openapi-derefed.json` with a warning if missing)
- **`test/normalize-spec.test.ts`**: tests covering singularization, path parsing, name generation, and collision detection
- **`test/typecheck.ts`**, **`test/smoke.test.ts`**: updated to use normalized function names
- **`.gitignore`**: `openapi-normalized.json` excluded

### Breaking change

All generated SDK function names change. This ships as `@sentry/api@1.0.0`. Consumers (CLI, MCP) need to update their imports — the mapping is mechanical and deterministic.
