### PR TITLE
feat: SDK auth/client config factories (bearerToken, browserSession, createSentryClient)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,61 @@ npm install @sentry/api
 
 ## Usage
 
-Pass `baseUrl` and an auth header to each call:
+Configure the client once, then call any operation without repeating auth or host.
+`bearerToken(...)` is a pure factory that returns a config object; `client.setConfig(...)`
+applies it to the global client.
 
 ```ts
-import { listYourOrganizations } from "@sentry/api";
+import { client, bearerToken, listYourOrganizations } from "@sentry/api";
 
-const { data, error } = await listYourOrganizations({
-  baseUrl: "https://sentry.io",
-  headers: { Authorization: `Bearer ${process.env.SENTRY_AUTH_TOKEN}` },
-});
+client.setConfig(bearerToken({ token: process.env.SENTRY_AUTH_TOKEN }));
 
+const { data, error } = await listYourOrganizations();
 if (error) throw error;
 console.log(data);
 ```
 
-Auth tokens and base URLs (including self-hosted and region URLs) are documented at https://docs.sentry.io/api/auth/.
+`bearerToken` defaults `baseUrl` to `https://sentry.io`. For self-hosted, or to pin a single
+region, pass your host:
+
+```ts
+client.setConfig(bearerToken({ token, baseUrl: "https://sentry.my-company.com" }));
+```
+
+### Isolated client (servers, tests)
+
+`client.setConfig(...)` mutates a global singleton, which is convenient for a single-token CLI.
+For a server that handles multiple tokens, or for tests, create an isolated instance with
+`createSentryClient(...)` and pass it per call:
+
+```ts
+import { createSentryClient, bearerToken, listYourOrganizations } from "@sentry/api";
+
+const sentry = createSentryClient(bearerToken({ token }));
+const { data } = await listYourOrganizations({ client: sentry });
+```
+
+### Browser (Sentry frontend)
+
+Use the `./browser` entry, which authenticates with the current session (cookies + CSRF),
+same-origin:
+
+```ts
+import { client } from "@sentry/api";
+import { browserSession } from "@sentry/api/browser";
+
+client.setConfig(browserSession());
+```
+
+### Custom transport
+
+`bearerToken` accepts a `fetch` option for transport policy the SDK does not own (token refresh,
+retries, timeouts, custom CA, tracing). It also accepts `headers` (merged into every request) and
+`throwOnError`.
+
+You can always skip the factories and pass a raw config to `client.setConfig(...)`, or pass
+`baseUrl`/`headers` on an individual call to override. Auth tokens and base URLs (including
+self-hosted and region URLs) are documented at https://docs.sentry.io/api/auth/.
 
 ## Pagination
 

--- a/build.mjs
+++ b/build.mjs
@@ -35,6 +35,7 @@ await createClient({
 // 2. Copy hand-written utilities into the generated src/ directory
 cpSync("lib/sentry-pagination.ts", "src/sentry-pagination.ts");
 cpSync("lib/browser-client.ts", "src/browser-client.ts");
+cpSync("lib/auth-config.ts", "src/auth-config.ts");
 
 // 3. Generate per-operation pagination wrappers from the SDK output + spec.
 //    This post-processor inspects src/sdk.gen.ts and openapi-derefed.json,
@@ -44,8 +45,9 @@ cpSync("lib/browser-client.ts", "src/browser-client.ts");
 //    is documented as in-development and unstable.
 execSync(`node ${JSON.stringify(join(__dirname, "scripts", "generate-pagination.mjs"))}`, { stdio: "inherit" });
 
-// 4. Append re-exports to the generated index.ts so the pagination
-//    utilities and the per-operation wrappers are part of the public API.
+// 4. Append re-exports to the generated index.ts so the pagination utilities,
+//    the per-operation wrappers, the auth factories, and the client itself are
+//    all part of the public API surface.
 appendFileSync(
   "src/index.ts",
   [
@@ -53,6 +55,15 @@ appendFileSync(
     "export { parseSentryLinkHeader, unwrapResult, unwrapPaginatedResult, fetchPage, paginateAll, paginateUpTo } from './sentry-pagination.ts';",
     "export type { UnwrappedResult, PaginatedResponse, PaginateAllOptions, PaginateUpToOptions, PageFetcher, SdkResult } from './sentry-pagination.ts';",
     "export * from './pagination.gen.ts';",
+    // Auth/config factories (see lib/auth-config.ts). browserSession lives in ./browser.
+    "export { bearerToken, DEFAULT_BASE_URL } from './auth-config.ts';",
+    "export type { BearerTokenOptions, SentryApiConfig, FetchFn } from './auth-config.ts';",
+    // The client itself: the global singleton (client.setConfig) plus factories
+    // for isolated instances (createSentryClient is createClient, Sentry-branded).
+    "export { client } from './client.gen.ts';",
+    "export { createClient, createClient as createSentryClient, createConfig } from './client/index.ts';",
+    // Config only: `ClientOptions` is already re-exported from types.gen above.
+    "export type { Config } from './client/index.ts';",
     "",
   ].join("\n"),
 );

--- a/lib/auth-config.ts
+++ b/lib/auth-config.ts
@@ -1,0 +1,77 @@
+/**
+ * Auth + client configuration factories for @sentry/api.
+ *
+ * These are small, pure builders: they return a plain, typed config object that
+ * you hand to the SDK client, either globally via `client.setConfig(...)` or to
+ * an isolated instance via `createSentryClient(...)`. No side effects, no hidden
+ * lifecycle, no `mode` enum. If you prefer, pass the raw object yourself.
+ *
+ * Factories are named by authentication method (`bearerToken`; `browserSession`
+ * lives in ./browser). Host and routing are options, not separate factories.
+ */
+
+/** Standard fetch signature, without Bun/Node runtime extensions. */
+export type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/**
+ * The subset of the generated client `Config` these factories populate.
+ *
+ * Declared locally (not imported from the generated client) so this module
+ * stays standalone and unit-testable, mirroring `sentry-pagination.ts`. It is
+ * structurally compatible with the client's `Config`, so the result drops
+ * straight into `client.setConfig(...)` or `createSentryClient(...)`.
+ */
+export type SentryApiConfig = {
+  baseUrl?: string;
+  fetch?: FetchFn;
+  headers?: Record<string, string>;
+  throwOnError?: boolean;
+};
+
+/**
+ * Default host for Sentry's multi-region cloud. Its proxy routes org-scoped
+ * requests (the SDK's surface is org-scoped) to the correct region using the
+ * org slug in the path, so most consumers never need to think about regions.
+ */
+export const DEFAULT_BASE_URL = 'https://sentry.io';
+
+export type BearerTokenOptions = {
+  /** Auth token, sent as `Authorization: Bearer <token>`. */
+  token: string;
+  /**
+   * Base URL. Defaults to https://sentry.io (cloud), where the proxy routes by
+   * org slug. Set it for self-hosted or to pin a single region.
+   */
+  baseUrl?: string;
+  /**
+   * Custom fetch, for transport policy the SDK does not own: token refresh,
+   * retries, timeouts, custom CA, tracing. If it sets its own Authorization
+   * header, that wins over the bearer token here.
+   */
+  fetch?: FetchFn;
+  /** Extra headers merged into every request (e.g. `User-Agent`). */
+  headers?: Record<string, string>;
+  /** When true, SDK calls throw on error instead of returning `{ data, error }`. */
+  throwOnError?: boolean;
+};
+
+/**
+ * Config for token auth against Sentry (cloud or self-hosted).
+ *
+ * @example
+ * import { client, bearerToken } from '@sentry/api';
+ * client.setConfig(bearerToken({ token: process.env.SENTRY_AUTH_TOKEN }));
+ */
+export function bearerToken(opts: BearerTokenOptions): SentryApiConfig {
+  const config: SentryApiConfig = {
+    baseUrl: opts.baseUrl ?? DEFAULT_BASE_URL,
+    headers: { Authorization: `Bearer ${opts.token}`, ...opts.headers },
+  };
+  if (opts.fetch) {
+    config.fetch = opts.fetch;
+  }
+  if (opts.throwOnError !== undefined) {
+    config.throwOnError = opts.throwOnError;
+  }
+  return config;
+}

--- a/lib/browser-client.ts
+++ b/lib/browser-client.ts
@@ -78,3 +78,17 @@ export function createBrowserSdkConfig(opts: BrowserClientOptions = {}) {
     fetch: createBrowserFetch(opts),
   } as const;
 }
+
+/**
+ * Config for using the SDK from the Sentry frontend: same-origin, session
+ * cookies, CSRF. This is the blessed name; `createBrowserSdkConfig` remains as
+ * an alias. Named by auth method, consistent with `bearerToken` in the core entry.
+ *
+ * @example
+ * import { client } from '@sentry/api';
+ * import { browserSession } from '@sentry/api/browser';
+ * client.setConfig(browserSession());
+ */
+export function browserSession(opts: BrowserClientOptions = {}) {
+  return createBrowserSdkConfig(opts);
+}

--- a/test/auth-config.test.ts
+++ b/test/auth-config.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it} from 'bun:test';
+import {bearerToken, DEFAULT_BASE_URL, type FetchFn} from '../lib/auth-config.ts';
+import {browserSession, createBrowserSdkConfig} from '../lib/browser-client.ts';
+
+describe('bearerToken', () => {
+  it('defaults baseUrl to the Sentry cloud host', () => {
+    const config = bearerToken({token: 't'});
+    expect(config.baseUrl).toBe(DEFAULT_BASE_URL);
+    expect(DEFAULT_BASE_URL).toBe('https://sentry.io');
+  });
+
+  it('sets the Authorization: Bearer header', () => {
+    const config = bearerToken({token: 'abc123'});
+    expect(config.headers?.Authorization).toBe('Bearer abc123');
+  });
+
+  it('honors a custom baseUrl (self-hosted / pinned region)', () => {
+    const config = bearerToken({token: 't', baseUrl: 'https://sentry.acme.com'});
+    expect(config.baseUrl).toBe('https://sentry.acme.com');
+  });
+
+  it('merges extra headers alongside Authorization', () => {
+    const config = bearerToken({token: 't', headers: {'User-Agent': 'sentry-cli/1.0'}});
+    expect(config.headers?.Authorization).toBe('Bearer t');
+    expect(config.headers?.['User-Agent']).toBe('sentry-cli/1.0');
+  });
+
+  it('lets a caller header override the default (last write wins)', () => {
+    const config = bearerToken({token: 't', headers: {Authorization: 'Bearer override'}});
+    expect(config.headers?.Authorization).toBe('Bearer override');
+  });
+
+  it('passes through a custom fetch and throwOnError', () => {
+    const fetch: FetchFn = async () => new Response('{}');
+    const config = bearerToken({token: 't', fetch, throwOnError: true});
+    expect(config.fetch).toBe(fetch);
+    expect(config.throwOnError).toBe(true);
+  });
+
+  it('omits fetch and throwOnError when not provided', () => {
+    const config = bearerToken({token: 't'});
+    expect(config.fetch).toBeUndefined();
+    expect(config.throwOnError).toBeUndefined();
+  });
+});
+
+describe('browserSession', () => {
+  it('is the blessed alias of createBrowserSdkConfig (same shape)', () => {
+    const a = browserSession();
+    const b = createBrowserSdkConfig();
+    expect(a.baseUrl).toBe(b.baseUrl);
+    expect(a.baseUrl).toBe('');
+    expect(typeof a.fetch).toBe('function');
+  });
+});


### PR DESCRIPTION
## What

First of three small, additive PRs making `@sentry/api` a one-line-to-configure client for the CLI, MCP, and frontend, instead of threading `baseUrl` + auth into every call.

This PR adds the **auth/init factories** and exposes the client from the public entry. No region routing yet (PR2), no query-accuracy helper (PR3).

## Changes

- `lib/auth-config.ts` (new): `bearerToken({ token, baseUrl?, fetch?, headers?, throwOnError? })` — a pure factory returning a typed config. Defaults `baseUrl` to `https://sentry.io`. Standalone (local types, no generated imports), same pattern as `lib/sentry-pagination.ts`.
- `lib/browser-client.ts`: add `browserSession()` as the blessed name for the existing cookie+CSRF `createBrowserSdkConfig` (kept as an alias).
- `build.mjs`: copy `auth-config.ts` into the build and re-export from the public entry: `bearerToken`, `client`, `createClient`, `createClient as createSentryClient`, `createConfig`, and the `Config` type. (`client`/`createClient` were not exported before, despite the browser docstring assuming `import { client }`.)
- `README.md`: lead with configure-once usage; document the isolated-client and browser paths. Retires "pass baseUrl to each call."

## Design

- Factories named by **auth method** (`bearerToken`, `browserSession`); host/routing are options, not separate factories. No `configure`, no `init`, no `mode` enum, no "SaaS."
- `client.setConfig(...)` (global singleton) for the CLI; `createSentryClient(...)` (isolated instance) for servers like MCP and for tests, so a multi-token server never shares global mutable auth state.

## Usage

```ts
import { client, bearerToken, listYourOrganizations } from "@sentry/api";
client.setConfig(bearerToken({ token: process.env.SENTRY_AUTH_TOKEN }));
const { data } = await listYourOrganizations();   // no per-call baseUrl/headers
```

## Test plan

- `bun test`: 97 pass / 0 fail (8 new in `test/auth-config.test.ts`).
- `bun run build`: green; `bun run typecheck`: clean.
- Verified the **built** package: `bearerToken` -> sentry.io + `Bearer` header; `createSentryClient`/`createClient`/`client.setConfig` resolve; `browserSession()` -> `baseUrl: ''`; isolated client instantiates.

## Not in scope (follow-ups)

- PR2: `resolveRegionUrl` option + per-request region routing (default = sentry.io proxy).
- PR3: `queryWithAccuracy` (progressive sampling), + backend follow-up to add `sampling` to the spec.
- No CLI/MCP wiring until all three land.