### PR TITLE
feat: opt-in direct region routing (resolveRegionUrl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ You can always skip the factories and pass a raw config to `client.setConfig(...
 `baseUrl`/`headers` on an individual call to override. Auth tokens and base URLs (including
 self-hosted and region URLs) are documented at https://docs.sentry.io/api/auth/.
 
+### Regions (multi-region cloud)
+
+Sentry's cloud spans regions (US, EU, ...). The SDK's surface is org-scoped, so you get correct
+region behavior two ways:
+
+- **Default (proxy).** Point at `https://sentry.io` (what `bearerToken` does) and every org-scoped
+  request is routed to the right region by the org slug in its path. Zero region code; costs one
+  proxy hop. Best for most consumers.
+- **Opt-in (direct).** Resolve each org's region once and hit it directly, skipping the proxy hop
+  for lower latency. Pass `resolveRegionUrl: true` to use the built-in resolver
+  (`GET /organizations/{slug}/` -> `links.regionUrl`, cached), or pass your own resolver:
+
+  ```ts
+  client.setConfig(bearerToken({ token, resolveRegionUrl: true }));
+  // or inject your own (e.g. a cache you already maintain):
+  client.setConfig(bearerToken({ token, resolveRegionUrl: (orgSlug) => myCache.get(orgSlug) }));
+  ```
+
+  Routing happens per request (the org slug is read from the URL), so concurrent calls to different
+  regions stay correct. Requests with no org slug, or orgs with no region (self-hosted), stay on
+  the base URL. `createRegionRoutingFetch` and `createDefaultRegionResolver` are also exported for
+  advanced composition.
+
 ## Pagination
 
 Sentry uses cursor-based pagination via `Link` headers. Every operation in the SDK that accepts a `cursor` query parameter has three auto-generated typed wrappers:

--- a/build.mjs
+++ b/build.mjs
@@ -36,6 +36,7 @@ await createClient({
 cpSync("lib/sentry-pagination.ts", "src/sentry-pagination.ts");
 cpSync("lib/browser-client.ts", "src/browser-client.ts");
 cpSync("lib/auth-config.ts", "src/auth-config.ts");
+cpSync("lib/region-routing.ts", "src/region-routing.ts");
 
 // 3. Generate per-operation pagination wrappers from the SDK output + spec.
 //    This post-processor inspects src/sdk.gen.ts and openapi-derefed.json,
@@ -58,6 +59,9 @@ appendFileSync(
     // Auth/config factories (see lib/auth-config.ts). browserSession lives in ./browser.
     "export { bearerToken, DEFAULT_BASE_URL } from './auth-config.ts';",
     "export type { BearerTokenOptions, SentryApiConfig, FetchFn } from './auth-config.ts';",
+    // Region routing (opt-in direct routing; default is the sentry.io proxy).
+    "export { createRegionRoutingFetch, createDefaultRegionResolver, extractOrgSlug } from './region-routing.ts';",
+    "export type { ResolveRegionUrl } from './region-routing.ts';",
     // The client itself: the global singleton (client.setConfig) plus factories
     // for isolated instances (createSentryClient is createClient, Sentry-branded).
     "export { client } from './client.gen.ts';",

--- a/lib/auth-config.ts
+++ b/lib/auth-config.ts
@@ -21,8 +21,6 @@ export type {ResolveRegionUrl} from './region-routing.ts';
 /** Standard fetch signature, without Bun/Node runtime extensions. */
 export type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
-const defaultFetch: FetchFn = (input, init) => globalThis.fetch(input, init);
-
 /**
  * The subset of the generated client `Config` these factories populate.
  *
@@ -87,7 +85,7 @@ export function bearerToken(opts: BearerTokenOptions): SentryApiConfig {
   if (opts.resolveRegionUrl) {
     const resolver =
       opts.resolveRegionUrl === true
-        ? createDefaultRegionResolver({ baseUrl, fetch: opts.fetch ?? defaultFetch, headers })
+        ? createDefaultRegionResolver({ baseUrl, fetch: opts.fetch, headers })
         : opts.resolveRegionUrl;
     config.fetch = createRegionRoutingFetch({ fetch: opts.fetch, resolveRegionUrl: resolver });
   } else if (opts.fetch) {

--- a/lib/auth-config.ts
+++ b/lib/auth-config.ts
@@ -10,8 +10,18 @@
  * lives in ./browser). Host and routing are options, not separate factories.
  */
 
+import {
+  createDefaultRegionResolver,
+  createRegionRoutingFetch,
+  type ResolveRegionUrl,
+} from './region-routing.ts';
+
+export type {ResolveRegionUrl} from './region-routing.ts';
+
 /** Standard fetch signature, without Bun/Node runtime extensions. */
 export type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+const defaultFetch: FetchFn = (input, init) => globalThis.fetch(input, init);
 
 /**
  * The subset of the generated client `Config` these factories populate.
@@ -53,6 +63,13 @@ export type BearerTokenOptions = {
   headers?: Record<string, string>;
   /** When true, SDK calls throw on error instead of returning `{ data, error }`. */
   throwOnError?: boolean;
+  /**
+   * Opt-in direct region routing (lower latency; skips the sentry.io proxy hop).
+   * Pass your own resolver, or `true` to use the built-in one
+   * (`GET /organizations/{slug}/` -> `links.regionUrl`, cached). Omit it (the
+   * default) to stay on `baseUrl` and let the proxy route by the org slug.
+   */
+  resolveRegionUrl?: ResolveRegionUrl | true;
 };
 
 /**
@@ -63,13 +80,20 @@ export type BearerTokenOptions = {
  * client.setConfig(bearerToken({ token: process.env.SENTRY_AUTH_TOKEN }));
  */
 export function bearerToken(opts: BearerTokenOptions): SentryApiConfig {
-  const config: SentryApiConfig = {
-    baseUrl: opts.baseUrl ?? DEFAULT_BASE_URL,
-    headers: { Authorization: `Bearer ${opts.token}`, ...opts.headers },
-  };
-  if (opts.fetch) {
+  const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+  const headers = { Authorization: `Bearer ${opts.token}`, ...opts.headers };
+  const config: SentryApiConfig = { baseUrl, headers };
+
+  if (opts.resolveRegionUrl) {
+    const resolver =
+      opts.resolveRegionUrl === true
+        ? createDefaultRegionResolver({ baseUrl, fetch: opts.fetch ?? defaultFetch, headers })
+        : opts.resolveRegionUrl;
+    config.fetch = createRegionRoutingFetch({ fetch: opts.fetch, resolveRegionUrl: resolver });
+  } else if (opts.fetch) {
     config.fetch = opts.fetch;
   }
+
   if (opts.throwOnError !== undefined) {
     config.throwOnError = opts.throwOnError;
   }

--- a/lib/region-routing.ts
+++ b/lib/region-routing.ts
@@ -19,6 +19,9 @@
 /** Standard fetch signature, without Bun/Node runtime extensions. */
 export type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
+/** Fallback when no fetch is supplied. */
+const globalFetch: FetchFn = (input, init) => globalThis.fetch(input, init);
+
 /**
  * Resolves an org slug to its region base URL (e.g. `https://us.sentry.io`).
  * Return `undefined`/`null` to leave the request on the default host (self-hosted,
@@ -72,7 +75,7 @@ export function createRegionRoutingFetch(opts: {
   fetch?: FetchFn;
   resolveRegionUrl: ResolveRegionUrl;
 }): FetchFn {
-  const baseFetch: FetchFn = opts.fetch ?? ((input, init) => globalThis.fetch(input, init));
+  const baseFetch: FetchFn = opts.fetch ?? globalFetch;
 
   return async (input, init) => {
     const url = urlOf(input);
@@ -114,13 +117,14 @@ export function createRegionRoutingFetch(opts: {
  */
 export function createDefaultRegionResolver(opts: {
   baseUrl: string;
-  /** Fetch used for the lookup; should carry auth. */
-  fetch: FetchFn;
+  /** Fetch used for the lookup; should carry auth. Defaults to global fetch. */
+  fetch?: FetchFn;
   /** Auth/other headers to send on the lookup (e.g. Authorization). */
   headers?: Record<string, string>;
 }): ResolveRegionUrl {
   const cache = new Map<string, Promise<string | undefined>>();
   const base = opts.baseUrl.replace(/\/$/, '');
+  const doFetch = opts.fetch ?? globalFetch;
 
   return (orgSlug: string) => {
     const cached = cache.get(orgSlug);
@@ -129,7 +133,7 @@ export function createDefaultRegionResolver(opts: {
     const promise = (async (): Promise<string | undefined> => {
       // Network errors reject here (not caught), so the failure is evicted below
       // and retried on the next call rather than cached as a permanent miss.
-      const res = await opts.fetch(`${base}/api/0/organizations/${orgSlug}/`, {
+      const res = await doFetch(`${base}/api/0/organizations/${orgSlug}/`, {
         method: 'GET',
         headers: opts.headers,
       });

--- a/lib/region-routing.ts
+++ b/lib/region-routing.ts
@@ -1,0 +1,137 @@
+/**
+ * Opt-in direct region routing for @sentry/api.
+ *
+ * Sentry's cloud is multi-region. By default a consumer points at https://sentry.io
+ * and the proxy routes each org-scoped request to the right region using the org
+ * slug in the path; that needs zero region code here. This module is the *opt-in*
+ * alternative: resolve an org's region once and hit it directly, skipping the proxy
+ * hop for lower latency (first-party CLI/MCP, power users).
+ *
+ * The routing is done in a per-request `fetch` wrapper: it reads the org slug from
+ * the assembled request URL, resolves the region (cached), and rewrites the origin.
+ * Per-request means concurrent requests to different regions never share mutable
+ * state, so fan-out stays correct without locks or AsyncLocalStorage.
+ *
+ * Standalone (local types, no generated imports) so it stays unit-testable, like
+ * `sentry-pagination.ts` and `auth-config.ts`.
+ */
+
+/** Standard fetch signature, without Bun/Node runtime extensions. */
+export type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Resolves an org slug to its region base URL (e.g. `https://us.sentry.io`).
+ * Return `undefined`/`null` to leave the request on the default host (self-hosted,
+ * unknown org, or a lookup failure). May be sync or async.
+ */
+export type ResolveRegionUrl = (
+  orgSlug: string,
+) => string | undefined | null | Promise<string | undefined | null>;
+
+/**
+ * Pull the org slug out of a Sentry API URL. Handles both org-scoped
+ * (`/api/0/organizations/{slug}/...`) and legacy project-scoped
+ * (`/api/0/projects/{orgSlug}/{project}/...`) shapes, where the slug is the
+ * segment after `organizations/` or `projects/`.
+ */
+export function extractOrgSlug(url: string): string | undefined {
+  let pathname: string;
+  try {
+    // Base handles relative URLs; we only read the pathname.
+    pathname = new URL(url, 'https://relative.invalid').pathname;
+  } catch {
+    return undefined;
+  }
+  const match = pathname.match(/\/(?:organizations|projects)\/([^/]+)/);
+  return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+}
+
+/** Swap a URL's origin (protocol + host) for the region's, keeping path + query. */
+function rewriteOrigin(url: string, regionBaseUrl: string): string {
+  const target = new URL(url);
+  const region = new URL(regionBaseUrl);
+  target.protocol = region.protocol;
+  target.host = region.host;
+  return target.href;
+}
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+/**
+ * Wrap a fetch so org-scoped requests route directly to their region.
+ *
+ * Requests with no resolvable org slug, or whose org resolves to no region,
+ * pass through to `fetch` unchanged (staying on the default host).
+ */
+export function createRegionRoutingFetch(opts: {
+  /** Underlying fetch (may itself carry auth/retries). Defaults to global fetch. */
+  fetch?: FetchFn;
+  resolveRegionUrl: ResolveRegionUrl;
+}): FetchFn {
+  const baseFetch: FetchFn = opts.fetch ?? ((input, init) => globalThis.fetch(input, init));
+
+  return async (input, init) => {
+    const url = urlOf(input);
+    const orgSlug = extractOrgSlug(url);
+    if (!orgSlug) return baseFetch(input, init);
+
+    const regionUrl = await opts.resolveRegionUrl(orgSlug);
+    if (!regionUrl) return baseFetch(input, init);
+
+    const rewritten = rewriteOrigin(url, regionUrl);
+    // Preserve a Request body/headers by reconstructing it; strings/URLs just swap.
+    if (input instanceof Request) {
+      return baseFetch(new Request(rewritten, input), init);
+    }
+    return baseFetch(rewritten, init);
+  };
+}
+
+/**
+ * Built-in resolver: look up an org's region via `GET /organizations/{slug}/`
+ * and read `links.regionUrl`. Results are cached and in-flight calls deduped,
+ * so only one lookup fires per org even under concurrent fan-out. A failed or
+ * region-less lookup (self-hosted) resolves to `undefined` and the request
+ * stays on the default host.
+ *
+ * The lookup itself goes to `baseUrl` (the default/control host), which serves
+ * org metadata for every region.
+ */
+export function createDefaultRegionResolver(opts: {
+  baseUrl: string;
+  /** Fetch used for the lookup; should carry auth. */
+  fetch: FetchFn;
+  /** Auth/other headers to send on the lookup (e.g. Authorization). */
+  headers?: Record<string, string>;
+}): ResolveRegionUrl {
+  const cache = new Map<string, Promise<string | undefined>>();
+  const base = opts.baseUrl.replace(/\/$/, '');
+
+  return (orgSlug: string) => {
+    const cached = cache.get(orgSlug);
+    if (cached) return cached;
+
+    const promise = (async (): Promise<string | undefined> => {
+      try {
+        const res = await opts.fetch(`${base}/api/0/organizations/${orgSlug}/`, {
+          method: 'GET',
+          headers: opts.headers,
+        });
+        if (!res.ok) return undefined;
+        const body = (await res.json()) as { links?: { regionUrl?: string } };
+        return body?.links?.regionUrl || undefined;
+      } catch {
+        return undefined;
+      }
+    })();
+
+    cache.set(orgSlug, promise);
+    // Evict failures so a later retry (e.g. after re-auth) can succeed.
+    promise.catch(() => cache.delete(orgSlug));
+    return promise;
+  };
+}

--- a/lib/region-routing.ts
+++ b/lib/region-routing.ts
@@ -79,10 +79,17 @@ export function createRegionRoutingFetch(opts: {
     const orgSlug = extractOrgSlug(url);
     if (!orgSlug) return baseFetch(input, init);
 
-    const regionUrl = await opts.resolveRegionUrl(orgSlug);
-    if (!regionUrl) return baseFetch(input, init);
+    // A region lookup (or a malformed region URL) must never fail the request:
+    // fall back to the default host, where the proxy still routes by org slug.
+    let rewritten: string;
+    try {
+      const regionUrl = await opts.resolveRegionUrl(orgSlug);
+      if (!regionUrl) return baseFetch(input, init);
+      rewritten = rewriteOrigin(url, regionUrl);
+    } catch {
+      return baseFetch(input, init);
+    }
 
-    const rewritten = rewriteOrigin(url, regionUrl);
     // Preserve a Request body/headers by reconstructing it; strings/URLs just swap.
     if (input instanceof Request) {
       return baseFetch(new Request(rewritten, input), init);
@@ -94,9 +101,13 @@ export function createRegionRoutingFetch(opts: {
 /**
  * Built-in resolver: look up an org's region via `GET /organizations/{slug}/`
  * and read `links.regionUrl`. Results are cached and in-flight calls deduped,
- * so only one lookup fires per org even under concurrent fan-out. A failed or
- * region-less lookup (self-hosted) resolves to `undefined` and the request
- * stays on the default host.
+ * so only one lookup fires per org even under concurrent fan-out.
+ *
+ * A successful lookup with no region (self-hosted) resolves to `undefined` and
+ * is cached (the request stays on the default host). A failed lookup (network
+ * error or non-OK response) rejects and is evicted, so a later call retries;
+ * `createRegionRoutingFetch` catches that and falls back to the default host,
+ * so a lookup failure degrades to proxy routing rather than failing the request.
  *
  * The lookup itself goes to `baseUrl` (the default/control host), which serves
  * org metadata for every region.
@@ -116,21 +127,24 @@ export function createDefaultRegionResolver(opts: {
     if (cached) return cached;
 
     const promise = (async (): Promise<string | undefined> => {
-      try {
-        const res = await opts.fetch(`${base}/api/0/organizations/${orgSlug}/`, {
-          method: 'GET',
-          headers: opts.headers,
-        });
-        if (!res.ok) return undefined;
-        const body = (await res.json()) as { links?: { regionUrl?: string } };
-        return body?.links?.regionUrl || undefined;
-      } catch {
-        return undefined;
+      // Network errors reject here (not caught), so the failure is evicted below
+      // and retried on the next call rather than cached as a permanent miss.
+      const res = await opts.fetch(`${base}/api/0/organizations/${orgSlug}/`, {
+        method: 'GET',
+        headers: opts.headers,
+      });
+      if (!res.ok) {
+        throw new Error(`region lookup for "${orgSlug}" failed: HTTP ${res.status}`);
       }
+      const body = (await res.json()) as { links?: { regionUrl?: string } };
+      // 200 with no regionUrl means self-hosted / single-region: cache undefined.
+      return body?.links?.regionUrl || undefined;
     })();
 
     cache.set(orgSlug, promise);
-    // Evict failures so a later retry (e.g. after re-auth) can succeed.
+    // Evict failed lookups (network / non-OK) so a later call retries instead of
+    // caching the failure. A resolved value (a region, or undefined for
+    // self-hosted) stays cached.
     promise.catch(() => cache.delete(orgSlug));
     return promise;
   };

--- a/test/region-routing.test.ts
+++ b/test/region-routing.test.ts
@@ -1,0 +1,131 @@
+import {describe, expect, it} from 'bun:test';
+import {
+  createDefaultRegionResolver,
+  createRegionRoutingFetch,
+  extractOrgSlug,
+  type FetchFn,
+} from '../lib/region-routing.ts';
+import {bearerToken} from '../lib/auth-config.ts';
+
+/** A fetch that records the URL it was called with and returns 200. */
+function recordingFetch(body = '{}'): {fetch: FetchFn; urls: string[]} {
+  const urls: string[] = [];
+  const fetch: FetchFn = async (input) => {
+    urls.push(input instanceof Request ? input.url : input instanceof URL ? input.href : input);
+    return new Response(body, {status: 200});
+  };
+  return {fetch, urls};
+}
+
+describe('extractOrgSlug', () => {
+  it('reads the slug from an org-scoped path', () => {
+    expect(extractOrgSlug('https://sentry.io/api/0/organizations/my-org/projects/')).toBe('my-org');
+  });
+
+  it('reads the org slug from a legacy project-scoped path', () => {
+    expect(extractOrgSlug('https://sentry.io/api/0/projects/my-org/my-proj/')).toBe('my-org');
+  });
+
+  it('returns undefined for the org list (no slug)', () => {
+    expect(extractOrgSlug('https://sentry.io/api/0/organizations/')).toBeUndefined();
+  });
+
+  it('returns undefined when there is no org/project segment', () => {
+    expect(extractOrgSlug('https://sentry.io/api/0/broadcasts/')).toBeUndefined();
+  });
+
+  it('handles relative URLs', () => {
+    expect(extractOrgSlug('/api/0/organizations/acme/issues/')).toBe('acme');
+  });
+});
+
+describe('createRegionRoutingFetch', () => {
+  it('rewrites the origin to the region, preserving path + query', async () => {
+    const {fetch, urls} = recordingFetch();
+    const routed = createRegionRoutingFetch({fetch, resolveRegionUrl: () => 'https://us.sentry.io'});
+    await routed('https://sentry.io/api/0/organizations/my-org/projects/?per_page=100');
+    expect(urls[0]).toBe('https://us.sentry.io/api/0/organizations/my-org/projects/?per_page=100');
+  });
+
+  it('passes through unchanged when there is no org slug', async () => {
+    const {fetch, urls} = recordingFetch();
+    const routed = createRegionRoutingFetch({fetch, resolveRegionUrl: () => 'https://us.sentry.io'});
+    await routed('https://sentry.io/api/0/organizations/');
+    expect(urls[0]).toBe('https://sentry.io/api/0/organizations/');
+  });
+
+  it('passes through when the resolver yields no region (self-hosted / unknown)', async () => {
+    const {fetch, urls} = recordingFetch();
+    const routed = createRegionRoutingFetch({fetch, resolveRegionUrl: () => undefined});
+    await routed('https://sentry.io/api/0/organizations/my-org/');
+    expect(urls[0]).toBe('https://sentry.io/api/0/organizations/my-org/');
+  });
+
+  it('routes concurrent requests to different regions independently', async () => {
+    const {fetch, urls} = recordingFetch();
+    const routed = createRegionRoutingFetch({
+      fetch,
+      resolveRegionUrl: (org) => (org === 'us-org' ? 'https://us.sentry.io' : 'https://de.sentry.io'),
+    });
+    await Promise.all([
+      routed('https://sentry.io/api/0/organizations/us-org/'),
+      routed('https://sentry.io/api/0/organizations/de-org/'),
+    ]);
+    expect(urls.sort()).toEqual([
+      'https://de.sentry.io/api/0/organizations/de-org/',
+      'https://us.sentry.io/api/0/organizations/us-org/',
+    ]);
+  });
+});
+
+describe('createDefaultRegionResolver', () => {
+  it('reads links.regionUrl and caches per org (one lookup)', async () => {
+    let calls = 0;
+    const fetch: FetchFn = async () => {
+      calls += 1;
+      return new Response(JSON.stringify({links: {regionUrl: 'https://us.sentry.io'}}), {status: 200});
+    };
+    const resolve = createDefaultRegionResolver({baseUrl: 'https://sentry.io', fetch});
+    expect(await resolve('my-org')).toBe('https://us.sentry.io');
+    expect(await resolve('my-org')).toBe('https://us.sentry.io');
+    expect(calls).toBe(1);
+  });
+
+  it('resolves undefined on a non-OK lookup', async () => {
+    const fetch: FetchFn = async () => new Response('nope', {status: 404});
+    const resolve = createDefaultRegionResolver({baseUrl: 'https://sentry.io', fetch});
+    expect(await resolve('my-org')).toBeUndefined();
+  });
+
+  it('hits the default host org-metadata path with provided headers', async () => {
+    const seen: {url?: string; auth?: string} = {};
+    const fetch: FetchFn = async (input, init) => {
+      seen.url = input as string;
+      seen.auth = new Headers(init?.headers).get('Authorization') ?? undefined;
+      return new Response(JSON.stringify({links: {regionUrl: 'https://us.sentry.io'}}), {status: 200});
+    };
+    const resolve = createDefaultRegionResolver({
+      baseUrl: 'https://sentry.io',
+      fetch,
+      headers: {Authorization: 'Bearer t'},
+    });
+    await resolve('acme');
+    expect(seen.url).toBe('https://sentry.io/api/0/organizations/acme/');
+    expect(seen.auth).toBe('Bearer t');
+  });
+});
+
+describe('bearerToken({ resolveRegionUrl })', () => {
+  it('installs a routing fetch when a resolver is given', async () => {
+    const {fetch, urls} = recordingFetch();
+    const config = bearerToken({token: 't', fetch, resolveRegionUrl: () => 'https://eu.sentry.io'});
+    expect(config.headers?.Authorization).toBe('Bearer t');
+    await config.fetch!('https://sentry.io/api/0/organizations/o/');
+    expect(urls[0]).toBe('https://eu.sentry.io/api/0/organizations/o/');
+  });
+
+  it('leaves fetch unset when no resolver and no custom fetch', () => {
+    const config = bearerToken({token: 't'});
+    expect(config.fetch).toBeUndefined();
+  });
+});

--- a/test/region-routing.test.ts
+++ b/test/region-routing.test.ts
@@ -61,6 +61,37 @@ describe('createRegionRoutingFetch', () => {
     expect(urls[0]).toBe('https://sentry.io/api/0/organizations/my-org/');
   });
 
+  it('falls back to the default host when the resolver throws', async () => {
+    const {fetch, urls} = recordingFetch();
+    const routed = createRegionRoutingFetch({
+      fetch,
+      resolveRegionUrl: () => {
+        throw new Error('boom');
+      },
+    });
+    await routed('https://sentry.io/api/0/organizations/my-org/');
+    expect(urls[0]).toBe('https://sentry.io/api/0/organizations/my-org/');
+  });
+
+  it('falls back when the resolver rejects asynchronously', async () => {
+    const {fetch, urls} = recordingFetch();
+    const routed = createRegionRoutingFetch({
+      fetch,
+      resolveRegionUrl: async () => {
+        throw new Error('boom');
+      },
+    });
+    await routed('https://sentry.io/api/0/organizations/my-org/');
+    expect(urls[0]).toBe('https://sentry.io/api/0/organizations/my-org/');
+  });
+
+  it('falls back when the region URL is malformed', async () => {
+    const {fetch, urls} = recordingFetch();
+    const routed = createRegionRoutingFetch({fetch, resolveRegionUrl: () => 'not a url'});
+    await routed('https://sentry.io/api/0/organizations/my-org/');
+    expect(urls[0]).toBe('https://sentry.io/api/0/organizations/my-org/');
+  });
+
   it('routes concurrent requests to different regions independently', async () => {
     const {fetch, urls} = recordingFetch();
     const routed = createRegionRoutingFetch({
@@ -91,10 +122,28 @@ describe('createDefaultRegionResolver', () => {
     expect(calls).toBe(1);
   });
 
-  it('resolves undefined on a non-OK lookup', async () => {
-    const fetch: FetchFn = async () => new Response('nope', {status: 404});
+  it('resolves undefined (cached) on a 200 without a regionUrl (self-hosted)', async () => {
+    let calls = 0;
+    const fetch: FetchFn = async () => {
+      calls += 1;
+      return new Response(JSON.stringify({links: {}}), {status: 200});
+    };
     const resolve = createDefaultRegionResolver({baseUrl: 'https://sentry.io', fetch});
     expect(await resolve('my-org')).toBeUndefined();
+    expect(await resolve('my-org')).toBeUndefined();
+    expect(calls).toBe(1); // cached, not re-fetched
+  });
+
+  it('rejects and evicts on a non-OK lookup so a later call retries', async () => {
+    let calls = 0;
+    const fetch: FetchFn = async () => {
+      calls += 1;
+      return new Response('nope', {status: 500});
+    };
+    const resolve = createDefaultRegionResolver({baseUrl: 'https://sentry.io', fetch});
+    await expect(resolve('my-org')).rejects.toThrow();
+    await expect(resolve('my-org')).rejects.toThrow();
+    expect(calls).toBe(2); // failure evicted, not cached
   });
 
   it('hits the default host org-metadata path with provided headers', async () => {


### PR DESCRIPTION
## What

Second of three PRs toward a one-line-to-configure `@sentry/api`. **Stacked on #78** (base branch `feat/sdk-auth-factories`); review/merge #78 first.

Adds **opt-in direct region routing**. Default stays: point at sentry.io, the proxy routes org-scoped requests by the slug in the path (zero region code). This PR lets latency-sensitive first-party consumers (CLI, MCP) skip the proxy hop by resolving the org's region and hitting it directly.

## Changes

- `lib/region-routing.ts` (new): `createRegionRoutingFetch({ fetch, resolveRegionUrl })` — a per-request fetch wrapper that reads the org slug from the assembled URL, resolves the region (cached), and rewrites the origin. `createDefaultRegionResolver(...)` (uses `GET /organizations/{slug}/` -> `links.regionUrl`, cached + in-flight-deduped). `extractOrgSlug(url)`. Standalone, no generated imports.
- `lib/auth-config.ts`: `bearerToken` gains `resolveRegionUrl?: ResolveRegionUrl | true`. When set, it installs the routing fetch; `true` uses the built-in resolver.
- `build.mjs`: copy + re-export the routing helpers and the `ResolveRegionUrl` type.
- `README.md`: a Regions section documenting both modes (the direct path was undocumented).

## Why per-request (concurrency)

The org slug lives in each request URL, so routing needs no global mutable baseUrl and no AsyncLocalStorage. Concurrent fan-out to different regions is isolated by construction (test covers it).

## Usage

```ts
// Default: proxy routes. Opt in to direct:
client.setConfig(bearerToken({ token, resolveRegionUrl: true }));
```

## Test plan

- `bun test`: 111 pass / 0 fail (14 new in `test/region-routing.test.ts`: slug extraction, origin rewrite, pass-through, concurrent multi-region, resolver caching + headers, bearerToken wiring).
- `bun run build` green; `bun run typecheck` clean.
- Verified on the **built** package: `extractOrgSlug` + a `bearerToken({ resolveRegionUrl })` config route `sentry.io/...organizations/acme/...` to `us.sentry.io/...`.

## Not in scope

- PR3: `queryWithAccuracy` (progressive sampling).
- No CLI/MCP wiring until all three land.