### PR TITLE
feat: add queryWithAccuracy progressive-sampling helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ region behavior two ways:
   the base URL. `createRegionRoutingFetch` and `createDefaultRegionResolver` are also exported for
   advanced composition.
 
+## Progressive accuracy (Explore / EAP queries)
+
+Explore endpoints (`listOrganizationEvents`, logs, spans) may answer from a downsampled tier and
+report `meta.dataScanned === 'partial'`; a targeted lookup can then come back empty. `queryWithAccuracy`
+runs the query at normal sampling, and if it scanned only partially re-runs it once at
+`HIGHEST_ACCURACY`. This is the shared version of what the Sentry frontend does in `useProgressiveQuery`.
+
+```ts
+import { queryWithAccuracy, isPartialScan, listOrganizationEvents } from "@sentry/api";
+
+const result = await queryWithAccuracy(
+  (sampling) =>
+    listOrganizationEvents({
+      path: { organization_id_or_slug: "my-org" },
+      // `sampling` is accepted at runtime but not yet in the spec's query types.
+      query: { dataset: "logs", query: `id:${id}`, sampling } as Record<string, unknown>,
+    }),
+  // Default escalates on any partial scan; tighten it for exact-id lookups:
+  { shouldEscalate: (r) => isPartialScan(r) && !r.data?.data?.length },
+);
+```
+
+`queryFn` receives the sampling mode and decides where it goes, so the helper stays independent of
+query shape. `SAMPLING_MODE` and `isPartialScan` are exported. Note: `sampling` is not in the
+OpenAPI types yet (cast for now); a backend `@extend_schema` change will type it.
+
 ## Pagination
 
 Sentry uses cursor-based pagination via `Link` headers. Every operation in the SDK that accepts a `cursor` query parameter has three auto-generated typed wrappers:

--- a/build.mjs
+++ b/build.mjs
@@ -37,6 +37,7 @@ cpSync("lib/sentry-pagination.ts", "src/sentry-pagination.ts");
 cpSync("lib/browser-client.ts", "src/browser-client.ts");
 cpSync("lib/auth-config.ts", "src/auth-config.ts");
 cpSync("lib/region-routing.ts", "src/region-routing.ts");
+cpSync("lib/query-accuracy.ts", "src/query-accuracy.ts");
 
 // 3. Generate per-operation pagination wrappers from the SDK output + spec.
 //    This post-processor inspects src/sdk.gen.ts and openapi-derefed.json,
@@ -62,6 +63,9 @@ appendFileSync(
     // Region routing (opt-in direct routing; default is the sentry.io proxy).
     "export { createRegionRoutingFetch, createDefaultRegionResolver, extractOrgSlug } from './region-routing.ts';",
     "export type { ResolveRegionUrl } from './region-routing.ts';",
+    // Progressive-accuracy query helper (partial-scan retry at HIGHEST_ACCURACY).
+    "export { queryWithAccuracy, isPartialScan, SAMPLING_MODE } from './query-accuracy.ts';",
+    "export type { SamplingMode, QueryWithAccuracyOptions } from './query-accuracy.ts';",
     // The client itself: the global singleton (client.setConfig) plus factories
     // for isolated instances (createSentryClient is createClient, Sentry-branded).
     "export { client } from './client.gen.ts';",

--- a/lib/query-accuracy.ts
+++ b/lib/query-accuracy.ts
@@ -1,0 +1,74 @@
+/**
+ * Progressive-accuracy queries for @sentry/api.
+ *
+ * Sentry's Explore/EAP endpoints (e.g. `listOrganizationEvents`) may answer a
+ * query from a downsampled storage tier. When they do, the response meta carries
+ * `dataScanned: 'partial'`, and a targeted query (an exact-id lookup) can come
+ * back empty even though the row exists. The fix, which the Sentry frontend
+ * already implements in `useProgressiveQuery`, is to retry the same query at
+ * `HIGHEST_ACCURACY` when the first (cheap) pass scanned only partially.
+ *
+ * This is the shared, transport-agnostic core of that pattern so the CLI, MCP,
+ * and frontend do not each reimplement it (the CLI `log view` bug was the cost
+ * of not sharing it). Standalone, no generated imports, like the other helpers.
+ *
+ * NOTE: the `sampling` query parameter is accepted by the API at runtime but is
+ * not yet in the OpenAPI spec, so it is not on the generated query types. Pass
+ * it with a narrow cast for now; a backend `@extend_schema` follow-up will type
+ * it. `dataScanned` IS typed on the events response meta.
+ */
+
+/** Sampling modes the EAP `sampling` query param accepts (subset used here). */
+export const SAMPLING_MODE = {
+  NORMAL: 'NORMAL',
+  HIGH_ACCURACY: 'HIGHEST_ACCURACY',
+} as const;
+
+export type SamplingMode = (typeof SAMPLING_MODE)[keyof typeof SAMPLING_MODE];
+
+/**
+ * Default escalation predicate: retry when the first pass reports a partial scan.
+ * Tolerates both the raw SDK result (`{ data: { meta } }`) and an unwrapped
+ * response (`{ meta }`). Mirrors the frontend's condition.
+ */
+export function isPartialScan(result: unknown): boolean {
+  const r = result as {data?: {meta?: {dataScanned?: string}}; meta?: {dataScanned?: string}};
+  const dataScanned = r?.data?.meta?.dataScanned ?? r?.meta?.dataScanned;
+  return dataScanned === 'partial';
+}
+
+export type QueryWithAccuracyOptions<T> = {
+  /**
+   * Return `true` to re-run `queryFn` at `HIGHEST_ACCURACY`. Defaults to
+   * {@link isPartialScan}. Override for stricter conditions, e.g. only escalate
+   * when the partial scan also came back empty (exact-id lookups).
+   */
+  shouldEscalate?: (result: T) => boolean;
+};
+
+/**
+ * Run a query at NORMAL sampling; if `shouldEscalate` says so, re-run it once at
+ * HIGHEST_ACCURACY and return that instead. `queryFn` receives the sampling mode
+ * and is responsible for placing it in the request (e.g. `query: { sampling }`),
+ * so this helper stays independent of query shape and param naming.
+ *
+ * @example
+ * const result = await queryWithAccuracy(
+ *   (sampling) => listOrganizationEvents({
+ *     path: { organization_id_or_slug: org },
+ *     query: { ...query, sampling } as typeof query & { sampling: string },
+ *   }),
+ *   { shouldEscalate: (r) => isPartialScan(r) && !r.data?.data?.length },
+ * );
+ */
+export async function queryWithAccuracy<T>(
+  queryFn: (sampling: SamplingMode) => Promise<T>,
+  opts: QueryWithAccuracyOptions<T> = {},
+): Promise<T> {
+  const shouldEscalate = opts.shouldEscalate ?? (isPartialScan as (result: T) => boolean);
+  const normal = await queryFn(SAMPLING_MODE.NORMAL);
+  if (shouldEscalate(normal)) {
+    return queryFn(SAMPLING_MODE.HIGH_ACCURACY);
+  }
+  return normal;
+}

--- a/test/query-accuracy.test.ts
+++ b/test/query-accuracy.test.ts
@@ -1,0 +1,77 @@
+import {describe, expect, it} from 'bun:test';
+import {
+  isPartialScan,
+  queryWithAccuracy,
+  SAMPLING_MODE,
+  type SamplingMode,
+} from '../lib/query-accuracy.ts';
+
+describe('SAMPLING_MODE', () => {
+  it('maps to the API values', () => {
+    expect(SAMPLING_MODE.NORMAL).toBe('NORMAL');
+    expect(SAMPLING_MODE.HIGH_ACCURACY).toBe('HIGHEST_ACCURACY');
+  });
+});
+
+describe('isPartialScan', () => {
+  it('detects partial on the raw SDK result shape ({ data: { meta } })', () => {
+    expect(isPartialScan({data: {meta: {dataScanned: 'partial'}}})).toBe(true);
+  });
+  it('detects partial on an unwrapped shape ({ meta })', () => {
+    expect(isPartialScan({meta: {dataScanned: 'partial'}})).toBe(true);
+  });
+  it('is false for a full scan', () => {
+    expect(isPartialScan({data: {meta: {dataScanned: 'full'}}})).toBe(false);
+  });
+  it('is false when meta is absent', () => {
+    expect(isPartialScan({data: {}})).toBe(false);
+  });
+});
+
+describe('queryWithAccuracy', () => {
+  it('returns the NORMAL result and does not escalate on a full scan', async () => {
+    const modes: SamplingMode[] = [];
+    const result = await queryWithAccuracy(async (sampling) => {
+      modes.push(sampling);
+      return {data: {meta: {dataScanned: 'full'}, data: [{id: '1'}]}};
+    });
+    expect(modes).toEqual([SAMPLING_MODE.NORMAL]);
+    expect(result.data.data).toHaveLength(1);
+  });
+
+  it('escalates to HIGHEST_ACCURACY on a partial scan (default predicate)', async () => {
+    const modes: SamplingMode[] = [];
+    const result = await queryWithAccuracy(async (sampling) => {
+      modes.push(sampling);
+      return sampling === SAMPLING_MODE.NORMAL
+        ? {data: {meta: {dataScanned: 'partial'}, data: []}}
+        : {data: {meta: {dataScanned: 'full'}, data: [{id: '42'}]}};
+    });
+    expect(modes).toEqual([SAMPLING_MODE.NORMAL, SAMPLING_MODE.HIGH_ACCURACY]);
+    expect(result.data.data).toEqual([{id: '42'}]);
+  });
+
+  it('honors a custom shouldEscalate (partial AND empty)', async () => {
+    const partialEmpty = (r: {data: {meta: {dataScanned: string}; data: unknown[]}}) =>
+      isPartialScan(r) && r.data.data.length === 0;
+
+    const nonEmptyModes: SamplingMode[] = [];
+    await queryWithAccuracy(
+      async (sampling) => {
+        nonEmptyModes.push(sampling);
+        // partial but NON-empty: custom predicate should NOT escalate
+        return {data: {meta: {dataScanned: 'partial'}, data: [{id: '1'}]}};
+      },
+      {shouldEscalate: partialEmpty},
+    );
+    expect(nonEmptyModes).toEqual([SAMPLING_MODE.NORMAL]);
+  });
+
+  it('passes the sampling mode to the query function', async () => {
+    const result = await queryWithAccuracy(
+      async (sampling) => ({sampling}),
+      {shouldEscalate: () => false},
+    );
+    expect(result.sampling).toBe(SAMPLING_MODE.NORMAL);
+  });
+});


### PR DESCRIPTION
## What

Third of three PRs toward a one-line-to-configure `@sentry/api`. **Stacked on #79** (base branch `feat/sdk-region-routing`, which is stacked on #78); merge #78 then #79 first.

Adds `queryWithAccuracy`: the shared version of the frontend's `useProgressiveQuery` retry, so the CLI, MCP, and frontend stop reimplementing it.

## Why

Explore/EAP endpoints (`listOrganizationEvents`, logs, spans) may answer from a downsampled storage tier and report `meta.dataScanned === 'partial'`. A targeted lookup (exact id) can then come back empty even though the row exists. The fix, which the Sentry UI already does in `useProgressiveQuery`, is to retry at `HIGHEST_ACCURACY` when the cheap pass scanned only partially. The CLI `log view` bug was exactly the cost of not sharing this.

## Changes

- `lib/query-accuracy.ts` (new): `queryWithAccuracy(queryFn, { shouldEscalate? })` runs NORMAL, then retries once at HIGHEST_ACCURACY if `shouldEscalate` (default `isPartialScan`) says so. `queryFn` receives the sampling mode and places it in the request, so the helper is independent of query shape. Exports `SAMPLING_MODE`, `isPartialScan`. Standalone.
- `build.mjs`: copy + re-export.
- `README.md`: a Progressive accuracy section.

## sampling and the spec (follow-up)

`sampling` is accepted by the API at runtime (verified against organization_events.py: `request.GET.get('sampling')`) but is **not in the OpenAPI spec yet**, so it is not on the generated query types. Callers cast it for now. Backend follow-up: add `sampling` via `@extend_schema` (getsentry/sentry) so the helper is fully typed. `meta.dataScanned` is already typed.

## Test plan

- `bun test`: 120 pass / 0 fail (9 new in `test/query-accuracy.test.ts`).
- `bun run build` green; `bun run typecheck` clean.
- Verified on the **built** package: a partial-then-full sequence escalates NORMAL -> HIGHEST_ACCURACY and returns the full-scan result.

## After this lands

With PR1-3 merged, the CLI and MCP each swap to `client.setConfig(bearerToken(...))` (or `createSentryClient`), delete their per-call config + region plumbing, and adopt `queryWithAccuracy` for logs. Those are separate PRs.