### PR TITLE
feat: add Valibot validation schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Auth tokens and base URLs (including self-hosted and region URLs) are documented
 
 The root `@sentry/api` entry has no runtime dependencies. It provides the API client and pure TypeScript types without installing a validation library.
 
-Runtime schemas are available through separate optional entry points:
+Valibot 1 runtime schemas are available through a separate optional entry point:
 
 ```bash
 npm install @sentry/api valibot
@@ -46,7 +46,7 @@ import { vGetProjectResponse } from "@sentry/api/valibot";
 const project = v.parse(vGetProjectResponse, input);
 ```
 
-Zod 4.4 and later remains supported:
+The existing Zod 3 entry remains supported:
 
 ```bash
 npm install @sentry/api zod
@@ -58,7 +58,7 @@ import { zGetProjectResponse } from "@sentry/api/zod";
 const project = zGetProjectResponse.parse(input);
 ```
 
-`valibot` and `zod` are optional peer dependencies. Install neither when you only need the generated client and TypeScript types, or install the validator used by your application.
+`valibot` and `zod` are optional peer dependencies. Install neither when you only need the generated client and TypeScript types, or install the validator used by your application. The `@sentry/api/valibot` entry requires Valibot 1; its optional peer uses a wildcard because npm applies peer constraints to the whole package, including consumers that never import this entry.
 
 ## Error handling
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,37 @@ console.log(data);
 
 Auth tokens and base URLs (including self-hosted and region URLs) are documented at https://docs.sentry.io/api/auth/.
 
+## Runtime validation
+
+The root `@sentry/api` entry has no runtime dependencies. It provides the API client and pure TypeScript types without installing a validation library.
+
+Runtime schemas are available through separate optional entry points:
+
+```bash
+npm install @sentry/api valibot
+```
+
+```ts
+import * as v from "valibot";
+import { vGetProjectResponse } from "@sentry/api/valibot";
+
+const project = v.parse(vGetProjectResponse, input);
+```
+
+Zod 4.4 and later remains supported:
+
+```bash
+npm install @sentry/api zod
+```
+
+```ts
+import { zGetProjectResponse } from "@sentry/api/zod";
+
+const project = zGetProjectResponse.parse(input);
+```
+
+`valibot` and `zod` are optional peer dependencies. Install neither when you only need the generated client and TypeScript types, or install the validator used by your application.
+
 ## Error handling
 
 Every operation with documented error responses has a generated `narrowError_<operation>` wrapper. It returns data or a `SentryApiError` that preserves the operation's status-to-body type map:

--- a/build.mjs
+++ b/build.mjs
@@ -15,19 +15,21 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 //     those were set intentionally via @extend_schema(operation_id=...).
 normalizeSpec("./openapi-derefed.json", "./openapi-normalized.json");
 
-// 1. Generate TypeScript client from OpenAPI spec (including Zod schemas).
+// 1. Generate TypeScript client from OpenAPI spec, including optional
+//    Valibot and Zod schemas.
 //    When `plugins` is specified, the defaults (TypeScript + SDK + client) are
 //    no longer implicit — list them explicitly so the previous output is
-//    preserved alongside the new Zod schemas.
+//    preserved alongside the validator schemas.
 await createClient({
   input: "./openapi-normalized.json",
   output: "src",
   plugins: [
     "@hey-api/typescript",
     "@hey-api/sdk",
+    "valibot",
     {
       name: "zod",
-      compatibilityVersion: 3,
+      compatibilityVersion: 4,
     },
   ],
 });
@@ -63,16 +65,17 @@ appendFileSync(
 );
 
 // 5. Create standalone entry points.
-//    zod: lets consumers import from "@sentry/api/zod" without pulling zod into
-//    code that only needs the SDK types and functions.
+//    valibot/zod: validator-specific schemas with optional peer dependencies.
 //    browser: CSRF + cookie auth helpers for browser/frontend use.
+writeFileSync("src/valibot.ts", 'export * from "./valibot.gen.ts";\n');
 writeFileSync("src/zod.ts", 'export * from "./zod.gen.ts";\n');
 writeFileSync("src/browser.ts", 'export * from "./browser-client.ts";\n');
 
 // 6. Bundle into JS files and emit type declarations.
 //    The main entry stays self-contained (zero runtime deps).
-//    The Zod entry externalises "zod" — consumers provide it themselves.
+//    Validator entries externalise their peers; the root stays dependency-free.
 execSync("bun build src/index.ts --outdir dist", { stdio: "inherit" });
+execSync('bun build src/valibot.ts --outdir dist --external valibot', { stdio: "inherit" });
 execSync('bun build src/zod.ts --outdir dist --external zod', { stdio: "inherit" });
 execSync("bun build src/browser.ts --outdir dist", { stdio: "inherit" });
 execSync("tsc --emitDeclarationOnly", { stdio: "inherit" });

--- a/build.mjs
+++ b/build.mjs
@@ -29,7 +29,7 @@ await createClient({
     "valibot",
     {
       name: "zod",
-      compatibilityVersion: 4,
+      compatibilityVersion: 3,
     },
   ],
 });

--- a/bun.lock
+++ b/bun.lock
@@ -9,12 +9,15 @@
         "@types/bun": "^1.3.13",
         "@types/node": "^22",
         "typescript": "^5.9.3",
-        "zod": "^3.24.0",
+        "valibot": "^1.4.2",
+        "zod": "^4.4.3",
       },
       "peerDependencies": {
-        "zod": "^3.24.0",
+        "valibot": ">=1.0.0 <2",
+        "zod": ">=4.4.0 <5",
       },
       "optionalPeers": [
+        "valibot",
         "zod",
       ],
     },
@@ -130,11 +133,13 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "nypm/citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -10,11 +10,11 @@
         "@types/node": "^22",
         "typescript": "^5.9.3",
         "valibot": "^1.4.2",
-        "zod": "^4.4.3",
+        "zod": "^3.24.0",
       },
       "peerDependencies": {
-        "valibot": ">=1.0.0 <2",
-        "zod": ">=4.4.0 <5",
+        "valibot": "*",
+        "zod": "^3.24.0",
       },
       "optionalPeers": [
         "valibot",
@@ -139,7 +139,7 @@
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "nypm/citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       "import": "./dist/zod.js",
       "types": "./dist/zod.d.ts"
     },
+    "./valibot": {
+      "import": "./dist/valibot.js",
+      "types": "./dist/valibot.d.ts"
+    },
     "./browser": {
       "import": "./dist/browser.js",
       "types": "./dist/browser.d.ts"
@@ -47,9 +51,13 @@
     "url": "https://github.com/getsentry/sentry-api-schema/issues"
   },
   "peerDependencies": {
-    "zod": "^3.24.0"
+    "valibot": ">=1.0.0 <2",
+    "zod": ">=4.4.0 <5"
   },
   "peerDependenciesMeta": {
+    "valibot": {
+      "optional": true
+    },
     "zod": {
       "optional": true
     }
@@ -59,7 +67,8 @@
     "@types/bun": "^1.3.13",
     "@types/node": "^22",
     "typescript": "^5.9.3",
-    "zod": "^3.24.0"
+    "valibot": "^1.4.2",
+    "zod": "^4.4.3"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "url": "https://github.com/getsentry/sentry-api-schema/issues"
   },
   "peerDependencies": {
-    "valibot": ">=1.0.0 <2",
-    "zod": ">=4.4.0 <5"
+    "valibot": "*",
+    "zod": "^3.24.0"
   },
   "peerDependenciesMeta": {
     "valibot": {
@@ -68,7 +68,7 @@
     "@types/node": "^22",
     "typescript": "^5.9.3",
     "valibot": "^1.4.2",
-    "zod": "^4.4.3"
+    "zod": "^3.24.0"
   },
   "engines": {
     "node": ">=22"

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -6,6 +6,10 @@ const readBundle = (name: string) =>
 
 describe("package entry points", () => {
   test("keeps validator peers optional", () => {
+    expect(packageJson.peerDependencies).toEqual({
+      valibot: "*",
+      zod: "^3.24.0",
+    });
     expect(packageJson.peerDependenciesMeta).toEqual({
       valibot: { optional: true },
       zod: { optional: true },

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import packageJson from "../package.json";
+
+const readBundle = (name: string) =>
+  Bun.file(new URL(`../dist/${name}.js`, import.meta.url)).text();
+
+describe("package entry points", () => {
+  test("keeps validator peers optional", () => {
+    expect(packageJson.peerDependenciesMeta).toEqual({
+      valibot: { optional: true },
+      zod: { optional: true },
+    });
+  });
+
+  test("keeps the root bundle independent from validators", async () => {
+    const root = await readBundle("index");
+    expect(root).not.toMatch(/from ["']valibot["']/);
+    expect(root).not.toMatch(/from ["']zod["']/);
+  });
+
+  test("isolates each validator to its own entry point", async () => {
+    const [valibot, zod] = await Promise.all([
+      readBundle("valibot"),
+      readBundle("zod"),
+    ]);
+    expect(valibot).toMatch(/from ["']valibot["']/);
+    expect(valibot).not.toMatch(/from ["']zod["']/);
+    expect(zod).toMatch(/from ["']zod["']/);
+    expect(zod).not.toMatch(/from ["']valibot["']/);
+  });
+});

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -92,7 +92,7 @@ describe("runtime validator entry points", () => {
     ).toThrow();
   });
 
-  test("Zod 4 parses generated response schemas", () => {
+  test("Zod parses generated response schemas", () => {
     expect(zAutofixPostResponse.parse(response)).toEqual(response);
     expect(() =>
       zAutofixPostResponse.parse({ ...response, run_id: "42" }),

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+import { vAutofixPostResponse } from "../src/valibot";
+import { zAutofixPostResponse } from "../src/zod";
 import {
   fetchPage,
   fetchPage_listOrganizationIssues,
@@ -76,6 +79,24 @@ describe("parseSentryLinkHeader", () => {
   test("ignores malformed segments without crashing", () => {
     expect(parseSentryLinkHeader("not a link header")).toEqual({});
     expect(parseSentryLinkHeader("<url>; rel=next")).toEqual({}); // unquoted
+  });
+});
+
+describe("runtime validator entry points", () => {
+  const response = { run_id: 42, sentry_run_id: "run-42" };
+
+  test("Valibot parses generated response schemas", () => {
+    expect(v.parse(vAutofixPostResponse, response)).toEqual(response);
+    expect(() =>
+      v.parse(vAutofixPostResponse, { ...response, run_id: "42" }),
+    ).toThrow();
+  });
+
+  test("Zod 4 parses generated response schemas", () => {
+    expect(zAutofixPostResponse.parse(response)).toEqual(response);
+    expect(() =>
+      zAutofixPostResponse.parse({ ...response, run_id: "42" }),
+    ).toThrow();
   });
 });
 

--- a/test/typecheck.ts
+++ b/test/typecheck.ts
@@ -21,6 +21,17 @@ import {
   paginateAll_listOrganizationProjects,
   paginateUpTo_listOrganizationIssues,
 } from "../src/index";
+import type { InferOutput } from "valibot";
+import type { z } from "zod";
+import { vAutofixPostResponse } from "../src/valibot";
+import { zAutofixPostResponse } from "../src/zod";
+
+const valibotResponse: InferOutput<typeof vAutofixPostResponse> = {
+  run_id: 1,
+  sentry_run_id: null,
+};
+const zodResponse: z.infer<typeof zAutofixPostResponse> = valibotResponse;
+void zodResponse;
 
 const config = {
   baseUrl: "https://sentry.io",


### PR DESCRIPTION
## Summary

Adds Valibot runtime schemas while keeping Zod and dependency-free consumers supported through separate package entry points.

- `@sentry/api` remains a zero-runtime-dependency client with pure TypeScript types.
- `@sentry/api/valibot` exposes generated Valibot 1 schemas.
- `@sentry/api/zod` keeps its existing Zod 3 schema contract.
- `valibot` and `zod` are optional peer dependencies, so consumers install neither, either, or both.
- Validator bundles externalize their own peer and never pull the other validator into an application.

## Usage

```ts
import * as v from "valibot";
import { vGetProjectResponse } from "@sentry/api/valibot";

const project = v.parse(vGetProjectResponse, input);
```

```ts
import { zGetProjectResponse } from "@sentry/api/zod";

const project = zGetProjectResponse.parse(input);
```

## Testing

- `bun run build`
- `bun run typecheck`
- `bun test`: 103 passing
- Packed-package compatibility checks:
  - root package with neither validator installed
  - root package with Zod 3 and Valibot 0 already installed
  - Valibot entry runtime and declarations with Valibot 1.4.2
  - Zod entry runtime and declarations with Zod 3.24.0

The Valibot optional peer uses a wildcard because npm applies peer constraints to the whole package, including consumers that never import `@sentry/api/valibot`. The Valibot entry itself requires Valibot 1.
